### PR TITLE
codepocket-demo에서 codepocket-external로 이름 변경

### DIFF
--- a/.github/workflows/deploy-codepocket-demo.yml
+++ b/.github/workflows/deploy-codepocket-demo.yml
@@ -3,11 +3,11 @@ on:
     branches:
       - main
 
-name: codepocket demo 배포
+name: codepocket external 배포
 
 jobs:
-  deploy-codepocket-demo:
-    name: codepocket demo 배포
+  deploy-codepocket-external:
+    name: codepocket external 배포
     runs-on: ubuntu-latest
 
     steps:
@@ -36,4 +36,4 @@ jobs:
         with:
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           apiToken: ${{ secrets.CF_API_TOKEN }}
-          command: pages publish ./client/dist --project-name=codepocket-demo
+          command: pages publish ./client/dist --project-name=codepocket-external


### PR DESCRIPTION
closes #72 

SRE팀과 얘기한 결과 `codepocket-demo` 보다는 `codepocket-external`으로 이름을 가져가는게 좋을 것 같다고 하여 그렇게 했어용
그리고 수정사항은 프로젝트명이 바꼈으니 cloudflare pages CD 고쳐줬슴당