### PR TITLE
cli 배포 버전 맞추기

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -25,7 +25,7 @@
     "test:log": "NODE_ENV=development jest"
   },
   "dependencies": {
-    "@codepocket/schema": "^0.0.1",
+    "@codepocket/schema": "^0.0.3",
     "await-to-js": "^3.0.0",
     "axios": "^0.27.2",
     "chalk": "^5.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@auth0/auth0-react": "^1.10.2",
-    "@codepocket/schema": "^0.0.1",
+    "@codepocket/schema": "^0.0.3",
     "@codesandbox/sandpack-react": "^1.2.4",
     "@codesandbox/sandpack-themes": "^1.0.0",
     "@karrotmarket/design-token": "^1.1.2",

--- a/core/server/package.json
+++ b/core/server/package.json
@@ -13,7 +13,7 @@
     "re:build": "rescript"
   },
   "dependencies": {
-    "@codepocket/schema": "^0.0.1"
+    "@codepocket/schema": "^0.0.3"
   },
   "devDependencies": {
     "gentype": "^4.5.0",

--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@codepocket/core-server": "^0.0.1",
-    "@codepocket/schema": "^0.0.1",
+    "@codepocket/schema": "^0.0.3",
     "@fastify/cors": "^8.0.0",
     "@fastify/mongodb": "^6.0.1",
     "await-to-js": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,7 +1899,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@codepocket/cli@workspace:cli"
   dependencies:
-    "@codepocket/schema": ^0.0.0
+    "@codepocket/schema": ^0.0.3
     "@swc/core": ^1.2.211
     "@swc/jest": ^0.2.21
     "@types/dotenv-safe": ^8
@@ -1927,7 +1927,7 @@ __metadata:
   dependencies:
     "@auth0/auth0-react": ^1.10.2
     "@babel/core": ^7.18.6
-    "@codepocket/schema": ^0.0.0
+    "@codepocket/schema": ^0.0.3
     "@codesandbox/sandpack-react": ^1.2.4
     "@codesandbox/sandpack-themes": ^1.0.0
     "@karrotmarket/design-token": ^1.1.2
@@ -1978,11 +1978,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@codepocket/core-server@^0.0.0, @codepocket/core-server@workspace:core/server":
+"@codepocket/core-server@^0.0.1, @codepocket/core-server@workspace:core/server":
   version: 0.0.0-use.local
   resolution: "@codepocket/core-server@workspace:core/server"
   dependencies:
-    "@codepocket/schema": ^0.0.0
+    "@codepocket/schema": ^0.0.3
     gentype: ^4.5.0
     rescript: ^9.1.4
     typescript: ^4.7.4
@@ -2011,7 +2011,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@codepocket/schema@^0.0.0, @codepocket/schema@workspace:schema":
+"@codepocket/schema@^0.0.3, @codepocket/schema@workspace:schema":
   version: 0.0.0-use.local
   resolution: "@codepocket/schema@workspace:schema"
   dependencies:
@@ -2028,8 +2028,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@codepocket/server@workspace:server"
   dependencies:
-    "@codepocket/core-server": ^0.0.0
-    "@codepocket/schema": ^0.0.0
+    "@codepocket/core-server": ^0.0.1
+    "@codepocket/schema": ^0.0.3
     "@fastify/cors": ^8.0.0
     "@fastify/mongodb": ^6.0.1
     "@types/dotenv-safe": ^8


### PR DESCRIPTION
closes #93 

- 앞에 Publish 같이 설명드리면 기존에 workspace:^로 참조하고 있던 버전을 ^0.0.0등 각 버전으로 변경해주었어요
- 메인에서 yarn lerna:publish를 실행하면 다 같이 퍼블리쉬를 할 수 있어요(cli, schema)
- cli 버전이 잘못되어서 추가적으로 pr날려요

- yarn lerna:publish를 하면 자동으로 커밋되는데 `이전에 작업한 내용이랑 구별을 잘 하는게` 좋을 것 같아요
- 우선 완료!
