### PR TITLE
github 로그인 처리

### DIFF
--- a/client/src/auth/Auth.tsx
+++ b/client/src/auth/Auth.tsx
@@ -17,9 +17,10 @@ const AuthPage: React.FC = () => {
   const { state: location } = useLocation() as UseLocation;
   const navigate = useNavigate();
   const { verifyUser } = useVerifyUser({ path: location?.path || pocketPath });
-  const { isAuthenticated, user, logout, loginWithPopup, isValidEmailDomain } = useCustomAuth0({
-    domain: EMAIL_DOMAIN_NAME,
-  });
+  const { isAuthenticated, user, isExternalUser, logout, loginWithPopup, isValidEmailDomain } =
+    useCustomAuth0({
+      domain: EMAIL_DOMAIN_NAME,
+    });
   const { createUser } = useCreateUser();
 
   useEffect(() => {
@@ -27,14 +28,18 @@ const AuthPage: React.FC = () => {
   }, [verifyUser]);
 
   useEffect(() => {
-    if (!isAuthenticated || !user || !user.nickname || !user.email) return;
+    if (!isAuthenticated || !user || !user.nickname) return;
     if (!isValidEmailDomain()) {
       window.alert('당근 유저가 아니에요!');
       logout();
       return;
     }
-    createUser({ userName: user.nickname, email: user.email });
-  }, [user, isValidEmailDomain, isAuthenticated, logout, navigate, createUser]);
+
+    const email = !isExternalUser ? user.email : '';
+    if (!email) return;
+
+    createUser({ userName: user.nickname, email });
+  }, [user, isValidEmailDomain, isAuthenticated, logout, navigate, createUser, isExternalUser]);
 
   return (
     <div className={style.wrapper}>

--- a/client/src/auth/hooks/useCustomAuth0.ts
+++ b/client/src/auth/hooks/useCustomAuth0.ts
@@ -1,5 +1,5 @@
 import { useAuth0 } from '@auth0/auth0-react';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 interface UseCustomAuth0Props {
   domain: string;
@@ -8,17 +8,19 @@ interface UseCustomAuth0Props {
 const useCustomAuth0 = ({ domain }: UseCustomAuth0Props) => {
   const { isAuthenticated, user, logout, loginWithPopup } = useAuth0();
 
+  const isExternalUser = useMemo(() => domain === '*', [domain]);
   const isValidEmailDomain = useCallback(() => {
-    if (!domain) return true; // NOTE: external은 email domain 검사 X
+    if (isExternalUser) return true;
     if (!user || !user.email) return false;
 
     const userDomain = user?.email.split('@')[1];
     return userDomain === domain;
-  }, [domain, user]);
+  }, [domain, isExternalUser, user]);
 
   return {
     user,
     isAuthenticated,
+    isExternalUser,
     loginWithPopup,
     logout,
     isValidEmailDomain,


### PR DESCRIPTION
closes #103 

깃허브로 로그인 했을 때 `email` 값이 유저 정보에 없어서 우선은 외부 유저들은 이메일 디비에 안넣는 식으로 했어요 (이건 논의 필요)

<img width="1007" alt="스크린샷 2022-08-11 오후 4 25 44" src="https://user-images.githubusercontent.com/54893898/184087430-8f1592d3-e608-4773-afc3-b198e68f8693.png">

그리고 기존에는 `VITE_EMAIL_DOMAIN_NAME` 환경변수를 안 넣으면 그냥 `external`로 판단해서 domain 판단로직을 바로 early return 하도록 했는데 와일드카드(*)로 받도록해서 `isExternal` 변수를 만들었어요


