### PR TITLE
client에서 서버 error 시각화 처리

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,7 @@
     "@codesandbox/sandpack-react": "^1.2.4",
     "@codesandbox/sandpack-themes": "^1.0.0",
     "@karrotmarket/design-token": "^1.1.2",
-    "@tanstack/react-query": "^4.0.5",
+    "@tanstack/react-query": "^4.1.3",
     "@tanstack/react-query-devtools": "^4.0.3",
     "@vanilla-extract/css": "^1.7.2",
     "@vanilla-extract/recipes": "^0.2.5",

--- a/client/src/auth/Auth.tsx
+++ b/client/src/auth/Auth.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-expressions */
 import { Icon, Modal } from '@shared/components';
 import { EMAIL_DOMAIN_NAME } from '@shared/constant';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -29,6 +30,16 @@ const AuthPage: React.FC = () => {
     setIsOpenModal(false);
     logout();
   }, [logout]);
+
+  const logoutBeforeLeaveTab = useCallback(() => {
+    if (isOpenModal) logout();
+  }, [isOpenModal, logout]);
+
+  useEffect(() => {
+    window.addEventListener('beforeunload', logoutBeforeLeaveTab);
+
+    () => window.removeEventListener('beforeunload', logoutBeforeLeaveTab);
+  }, [logoutBeforeLeaveTab]);
 
   useEffect(() => {
     verifyUser();

--- a/client/src/detail/Detail.tsx
+++ b/client/src/detail/Detail.tsx
@@ -1,5 +1,6 @@
 import { colors } from '@karrotmarket/design-token';
 import { Icon, Modal } from '@shared/components';
+import useModal from '@shared/hooks/useModal';
 import { Link, useParams } from 'react-router-dom';
 
 import { DetailPathParam, pocketPath } from '../routes';
@@ -7,7 +8,6 @@ import Sandpack from './components/Sandpack';
 import StoryNameList from './components/StoryNameList';
 import useCode from './hooks/useCode';
 import useCreateStory from './hooks/useCreateStory';
-import useErrorModal from './hooks/useErrorModal';
 import useStory from './hooks/useStory';
 import useStoryNames from './hooks/useStoryNames';
 import * as style from './style.css';
@@ -26,8 +26,8 @@ const DetailPage: React.FC = () => {
     codeId: codeId || '',
     selectStory,
   });
-  const { isModalOpened, closeModal } = useErrorModal({
-    isError: !!getCodeError || !!getStoryNamesError || !!createStoryError || !!getStoryError,
+  const { isModalOpened, closeModal } = useModal({
+    isOpened: !!getCodeError || !!getStoryNamesError || !!createStoryError || !!getStoryError,
   });
 
   return (

--- a/client/src/detail/Detail.tsx
+++ b/client/src/detail/Detail.tsx
@@ -1,6 +1,5 @@
 import { colors } from '@karrotmarket/design-token';
 import { Icon, Modal } from '@shared/components';
-import { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 
 import { DetailPathParam, pocketPath } from '../routes';
@@ -8,6 +7,7 @@ import Sandpack from './components/Sandpack';
 import StoryNameList from './components/StoryNameList';
 import useCode from './hooks/useCode';
 import useCreateStory from './hooks/useCreateStory';
+import useErrorModal from './hooks/useErrorModal';
 import useStory from './hooks/useStory';
 import useStoryNames from './hooks/useStoryNames';
 import * as style from './style.css';
@@ -15,7 +15,6 @@ import * as style from './style.css';
 // TODO: Suspense 적용하기
 const DetailPage: React.FC = () => {
   const { codeId } = useParams<keyof DetailPathParam>();
-  const [isOpenModal, setIsOpenModal] = useState(false);
   const { data: codeDataRes, error: getCodeError } = useCode({ codeId });
   const { data: storyNamesRes, error: getStoryNamesError } = useStoryNames({
     codeId: codeId || '',
@@ -27,16 +26,13 @@ const DetailPage: React.FC = () => {
     codeId: codeId || '',
     selectStory,
   });
-
-  const closeModal = () => setIsOpenModal(false);
-
-  useEffect(() => {
-    setIsOpenModal(!!getCodeError || !!getStoryNamesError || !!createStoryError || !getStoryError);
-  }, [getCodeError, getStoryNamesError, createStoryError, getStoryError]);
+  const { isModalOpened, closeModal } = useErrorModal({
+    isError: !!getCodeError || !!getStoryNamesError || !!createStoryError || !!getStoryError,
+  });
 
   return (
     <>
-      <Modal closeModal={closeModal} isOpen={!!isOpenModal} disableEscape>
+      <Modal closeModal={closeModal} isOpen={!!isModalOpened} disableEscape>
         <div className={style.modalContent}>
           <Icon icon="warningFill" color="red" />
           <div>{getCodeError?.response.data.message}</div>

--- a/client/src/detail/Detail.tsx
+++ b/client/src/detail/Detail.tsx
@@ -35,10 +35,7 @@ const DetailPage: React.FC = () => {
       <Modal closeModal={closeModal} isOpen={!!isModalOpened} disableEscape>
         <div className={style.modalContent}>
           <Icon icon="warningFill" color="red" />
-          <div>{getCodeError?.response.data.message}</div>
-          <div>{getStoryError?.response.data.message}</div>
-          <div>{createStoryError?.response.data.message}</div>
-          <div>{getStoryNamesError?.response.data.message}</div>
+          <div>코드들을 가져오는데 문제가 생겼어요</div>
         </div>
       </Modal>
       <div className={style.wrapper}>

--- a/client/src/detail/hooks/useCode.ts
+++ b/client/src/detail/hooks/useCode.ts
@@ -12,10 +12,6 @@ const useCode = ({ codeId }: UseCode) =>
     url: getCodeUrl,
     validator: getCodeResponseValidate,
     params: { codeId: `${codeId}` },
-    options: {
-      suspense: true,
-      useErrorBoundary: true,
-    },
   });
 
 export default useCode;

--- a/client/src/detail/hooks/useCreateStory.ts
+++ b/client/src/detail/hooks/useCreateStory.ts
@@ -21,7 +21,7 @@ interface UseCreateStory {
 const useCreateStory = ({ codeId, selectStory }: UseCreateStory) => {
   const queryClient = useQueryClient();
   const { user } = useAuth0();
-  const { mutate: createStoryMutate } = useCustomMutation<
+  const { mutate: createStoryMutate, error } = useCustomMutation<
     CreateStoryResponse,
     CreateStoryResponse,
     CreateStoryBodyType
@@ -45,9 +45,7 @@ const useCreateStory = ({ codeId, selectStory }: UseCreateStory) => {
     createStoryMutate({ codes, storyName, codeId, pocketToken });
   };
 
-  return {
-    createStory,
-  };
+  return { createStory, error };
 };
 
 export default useCreateStory;

--- a/client/src/detail/hooks/useErrorModal.ts
+++ b/client/src/detail/hooks/useErrorModal.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+interface UseErrorModal {
+  isError: boolean;
+}
+
+const useErrorModal = ({ isError }: UseErrorModal) => {
+  const [isModalOpened, setIsModalOpened] = useState(false);
+
+  const closeModal = () => setIsModalOpened(false);
+
+  useEffect(() => {
+    setIsModalOpened(isError);
+  }, [isError]);
+
+  return { closeModal, isModalOpened };
+};
+
+export default useErrorModal;

--- a/client/src/detail/hooks/useStory.ts
+++ b/client/src/detail/hooks/useStory.ts
@@ -8,7 +8,7 @@ import { SelectedStory } from '../components/Sandpack';
 const useStory = () => {
   const [selectedStory, setSelectedStory] = useState<SelectedStory>();
   const [selectedStoryId, setSelectedStoryId] = useState<string>('');
-  const { refetch: getStory } = useCustomQuery<GetStoryCodeResponse>({
+  const { refetch: getStory, error } = useCustomQuery<GetStoryCodeResponse>({
     url: getStoryCodeUrl,
     validator: getStoryCodeResponseValidate,
     params: {
@@ -36,6 +36,6 @@ const useStory = () => {
     getStoryCode();
   }, [selectedStoryId]);
 
-  return { selectedStory, selectedStoryId, selectStory };
+  return { selectedStory, error, selectedStoryId, selectStory };
 };
 export default useStory;

--- a/client/src/detail/hooks/useStory.ts
+++ b/client/src/detail/hooks/useStory.ts
@@ -15,8 +15,6 @@ const useStory = () => {
       storyId: selectedStoryId,
     },
     options: {
-      suspense: true,
-      useErrorBoundary: true,
       enabled: false,
     },
   });

--- a/client/src/detail/hooks/useStoryNames.ts
+++ b/client/src/detail/hooks/useStoryNames.ts
@@ -12,10 +12,6 @@ const useStoryNames = ({ codeId }: UseStoryNames) =>
     url: getStoryNamesUrl,
     validator: getStoryNamesResponseValidate,
     params: { codeId },
-    options: {
-      suspense: true,
-      useErrorBoundary: true,
-    },
   });
 
 export default useStoryNames;

--- a/client/src/detail/style.css.ts
+++ b/client/src/detail/style.css.ts
@@ -49,4 +49,14 @@ export const highlight = style({
   fontWeight: 'normal',
 });
 
-export const article = style([u.fullWidth, t.mt18]);
+export const article = style([u.fullWidth, t.mt18, { zIndex: -1 }]);
+
+export const modalContent = style([
+  u.flexColumn,
+  {
+    justifyContent: 'center',
+    alignItems: 'center',
+    rowGap: rem(10),
+    fontSize: rem(18),
+  },
+]);

--- a/client/src/pocket/Pocket.tsx
+++ b/client/src/pocket/Pocket.tsx
@@ -1,7 +1,10 @@
-import { CodeList, MoreButton, PendingFallback, Searchbar, SearchHelpText } from './components';
+import { CodeList, MoreButton, Searchbar, SearchHelpText } from './components';
+import CodeblockSkeleton from './components/CodeBlockSkeleton';
 import ErrorMessage from './components/ErrorMessage';
 import useCodes from './hooks/useCodes';
 import * as style from './style.css';
+
+const SKELETON_COUNT = 4;
 
 const PocketPage: React.FC = () => {
   const { codes, error, isLast, searchText, isLoading, changeSearchText, getNextCodes } =
@@ -13,12 +16,10 @@ const PocketPage: React.FC = () => {
       <Searchbar searchText={searchText} changeSearchText={changeSearchText} />
       {searchText ? <SearchHelpText searchText={searchText} /> : null}
       <CodeList codes={codes} />
-      {isLoading ? <PendingFallback /> : null}
-      {isLoading ? <PendingFallback /> : null}
-      {isLoading ? <PendingFallback /> : null}
-      {isLoading ? <PendingFallback /> : null}
-      {isLoading ? <PendingFallback /> : null}
-      {isLoading ? <PendingFallback /> : null}
+      {isLoading &&
+        Array(SKELETON_COUNT)
+          .fill(0)
+          .map(() => <CodeblockSkeleton />)}
       {!isLoading &&
         (!error ? (
           <MoreButton

--- a/client/src/pocket/Pocket.tsx
+++ b/client/src/pocket/Pocket.tsx
@@ -1,9 +1,10 @@
 import { CodeList, MoreButton, PendingFallback, Searchbar, SearchHelpText } from './components';
+import ErrorMessage from './components/ErrorMessage';
 import useCodes from './hooks/useCodes';
 import * as style from './style.css';
 
 const PocketPage: React.FC = () => {
-  const { codes, isLast, hasData, searchText, isLoading, changeSearchText, getNextCodes } =
+  const { codes, error, isLast, hasData, searchText, isLoading, changeSearchText, getNextCodes } =
     useCodes();
 
   return (
@@ -13,7 +14,22 @@ const PocketPage: React.FC = () => {
       {searchText ? <SearchHelpText searchText={searchText} /> : null}
       <CodeList codes={codes} />
       {isLoading ? <PendingFallback /> : null}
-      <MoreButton isLoading={isLoading} hasData={hasData} isLast={isLast} onClick={getNextCodes} />
+      {isLoading ? <PendingFallback /> : null}
+      {isLoading ? <PendingFallback /> : null}
+      {isLoading ? <PendingFallback /> : null}
+      {isLoading ? <PendingFallback /> : null}
+      {isLoading ? <PendingFallback /> : null}
+      {!isLoading &&
+        (!error ? (
+          <MoreButton
+            isLoading={isLoading}
+            hasData={hasData}
+            isLast={isLast}
+            onClick={getNextCodes}
+          />
+        ) : (
+          <ErrorMessage message={error.response.data.message} />
+        ))}
     </div>
   );
 };

--- a/client/src/pocket/Pocket.tsx
+++ b/client/src/pocket/Pocket.tsx
@@ -4,7 +4,7 @@ import useCodes from './hooks/useCodes';
 import * as style from './style.css';
 
 const PocketPage: React.FC = () => {
-  const { codes, error, isLast, hasData, searchText, isLoading, changeSearchText, getNextCodes } =
+  const { codes, error, isLast, searchText, isLoading, changeSearchText, getNextCodes } =
     useCodes();
 
   return (
@@ -23,7 +23,8 @@ const PocketPage: React.FC = () => {
         (!error ? (
           <MoreButton
             isLoading={isLoading}
-            hasData={hasData}
+            isSearch={!!searchText}
+            hasCode={!!codes.length}
             isLast={isLast}
             onClick={getNextCodes}
           />

--- a/client/src/pocket/components/CodeBlockSkeleton/index.tsx
+++ b/client/src/pocket/components/CodeBlockSkeleton/index.tsx
@@ -1,0 +1,27 @@
+import * as style from './style.css';
+
+const CodeblockSkeleton = () => {
+  return (
+    <div className={style.codeItem}>
+      <div className={style.codeItemHeaderInfo}>
+        <div className={style.codeItemHeaderCodeName}>
+          <span className={style.CodeNameSkeleton} />
+        </div>
+        <div className={style.codeItemHeaderCodeAuthor}>
+          <span className={style.AuthorNameSkeleton} />
+        </div>
+      </div>
+      <div className={style.codeItemCode} />
+      <div className={style.codeItemBottom}>
+        <div className={style.codeItemHeaderButtons}>
+          <div className={style.codeItemHeaderCopyButton} />
+          <div>
+            <div className={style.codeItemHeaderDetailButton} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CodeblockSkeleton;

--- a/client/src/pocket/components/CodeBlockSkeleton/style.css.ts
+++ b/client/src/pocket/components/CodeBlockSkeleton/style.css.ts
@@ -1,0 +1,122 @@
+import { colors } from '@karrotmarket/design-token';
+import * as m from '@shared/styles/media.css';
+import * as u from '@shared/styles/utils.css';
+import { keyframes, style } from '@vanilla-extract/css';
+import { rem } from 'polished';
+
+const gradation = keyframes({
+  '0%': { backgroundColor: colors.light.scheme.$gray100 },
+  '50%': { backgroundColor: colors.light.scheme.$gray300 },
+  '100%': { backgroundColor: colors.light.scheme.$gray100 },
+});
+
+export const gradationAnim = style([
+  {
+    backgroundColor: colors.light.scheme.$gray100,
+    animation: `2s infinite ${gradation}`,
+  },
+]);
+
+export const codeItem = style([
+  u.fullWidth,
+  u.borderRadius2,
+  {
+    marginTop: rem(50),
+    position: 'relative',
+  },
+]);
+
+export const codeItemHeaderInfo = style([
+  u.flexAlignCenter,
+  {
+    justifyContent: 'space-between',
+    columnGap: rem(30),
+    marginBottom: rem(10),
+  },
+  m.medium({
+    flexDirection: 'column-reverse',
+    alignItems: 'start',
+    rowGap: rem(5),
+  }),
+]);
+
+const NameSkeleton = style([u.borderRadius2, gradationAnim]);
+
+export const CodeNameSkeleton = style([
+  NameSkeleton,
+  {
+    width: rem(200),
+    height: rem(30),
+  },
+]);
+
+export const AuthorNameSkeleton = style([
+  NameSkeleton,
+  {
+    width: rem(150),
+    height: rem(30),
+  },
+]);
+
+export const codeItemHeaderCodeName = style([
+  u.flexCenter,
+  { columnGap: rem(7) },
+  m.medium({ marginLeft: rem(2) }),
+]);
+
+export const codeItemHeaderCodeAuthor = style([u.flexCenter, { columnGap: rem(7) }]);
+
+export const codeItemCode = style([
+  u.borderRadius2,
+  u.borderNone,
+  gradationAnim,
+  {
+    height: rem(160),
+    position: 'relative',
+  },
+]);
+
+export const codeItemBottom = style([
+  u.flex,
+  {
+    marginTop: rem(10),
+    justifyContent: 'flex-end',
+  },
+]);
+
+export const codeItemHeaderButtons = style([
+  u.flex,
+  {
+    columnGap: rem(5),
+  },
+]);
+
+export const codeItemButtonBase = style([
+  u.borderRadius,
+  u.borderNone,
+  u.flexAlignCenter,
+  gradationAnim,
+  m.medium({
+    width: rem(62),
+    fontSize: rem(12),
+  }),
+]);
+
+export const codeItemHeaderCopyButton = style([
+  codeItemButtonBase,
+  {
+    height: rem(30),
+    width: rem(70),
+  },
+  m.medium({
+    width: rem(50),
+  }),
+]);
+
+export const codeItemHeaderDetailButton = style([
+  codeItemButtonBase,
+  {
+    width: rem(100),
+    height: rem(30),
+  },
+]);

--- a/client/src/pocket/components/ErrorMessage/index.tsx
+++ b/client/src/pocket/components/ErrorMessage/index.tsx
@@ -1,0 +1,18 @@
+import { Icon } from '@shared/components';
+
+import * as style from './style.css';
+
+interface ErrorMessageProps {
+  message: string;
+}
+
+const ErrorMessage = ({ message }: ErrorMessageProps) => {
+  return (
+    <div className={style.alertBase}>
+      <Icon icon="warningFill" color="red" />
+      {message}
+    </div>
+  );
+};
+
+export default ErrorMessage;

--- a/client/src/pocket/components/ErrorMessage/style.css.ts
+++ b/client/src/pocket/components/ErrorMessage/style.css.ts
@@ -1,0 +1,16 @@
+import * as u from '@shared/styles/utils.css';
+import { style } from '@vanilla-extract/css';
+import { rem } from 'polished';
+
+export const alertBase = style([
+  u.fullWidth,
+  u.flexColumn,
+  u.flexCenter,
+  {
+    fontWeight: 'bold',
+    fontSize: rem(18),
+    margin: rem(30),
+    padding: rem(10),
+    gap: rem(15),
+  },
+]);

--- a/client/src/pocket/components/MoreButton/index.tsx
+++ b/client/src/pocket/components/MoreButton/index.tsx
@@ -3,19 +3,33 @@ import * as style from './style.css';
 
 interface MoreButtonInterface {
   onClick: () => void;
+  isSearch: boolean;
   isLast: boolean | undefined;
-  hasData: boolean;
+  hasCode: boolean;
   isLoading: boolean;
 }
 
-const MoreButton: React.FC<MoreButtonInterface> = ({ onClick, isLast, hasData, isLoading }) => {
+const MoreButton: React.FC<MoreButtonInterface> = ({
+  onClick,
+  isSearch,
+  isLast,
+  hasCode,
+  isLoading,
+}) => {
+  const getMessage = () => {
+    if (!isLast) return 'MORE';
+    if (!hasCode && isSearch) return '검색 결과에 해당하는 코드가 없어요';
+    if (!hasCode && !isSearch) return '빈 레지스트리예요';
+    return '마지막 코드예요';
+  };
+
   return (
     <button
       disabled={isLast}
       onClick={onClick}
       className={isLast || isLoading ? style.disableMoreButton : style.moreButton}
     >
-      {isLast ? (hasData ? '검색 결과에 해당하는 코드가 없어요' : '마지막 코드에요') : 'MORE'}
+      {getMessage()}
     </button>
   );
 };

--- a/client/src/pocket/hooks/useCodes.ts
+++ b/client/src/pocket/hooks/useCodes.ts
@@ -9,7 +9,7 @@ const useCodes = () => {
   const [offset, setOffset] = useState<number>(0);
   const [searchText, setSearchText] = useState<string>('');
 
-  const { data, refetch, isLoading } = useCustomQuery<GetCodesResponse>({
+  const { data, error, refetch, isLoading } = useCustomQuery<GetCodesResponse>({
     url: getCodesUrl,
     validator: getCodesResponseValidate,
     params: {
@@ -18,8 +18,6 @@ const useCodes = () => {
       offset: `${offset}`,
     },
     options: {
-      suspense: false,
-      useErrorBoundary: true,
       staleTime: 0,
       cacheTime: 0,
     },
@@ -55,6 +53,6 @@ const useCodes = () => {
     setCodes((prevCodes) => [...prevCodes, ...newCodes]);
   }, [searchText]);
 
-  return { codes, hasData, searchText, isLast, isLoading, changeSearchText, getNextCodes };
+  return { codes, error, hasData, searchText, isLast, isLoading, changeSearchText, getNextCodes };
 };
 export default useCodes;

--- a/client/src/pocket/hooks/useCodes.ts
+++ b/client/src/pocket/hooks/useCodes.ts
@@ -25,11 +25,6 @@ const useCodes = () => {
 
   const isLast = useMemo(() => data?.isLast, [data?.isLast]);
 
-  const hasData: boolean = useMemo(
-    () => !!(searchText && !codes.length),
-    [codes.length, searchText],
-  );
-
   const getNextCodes = useCallback(() => {
     refetch();
     setOffset((prev) => prev + 1);
@@ -53,6 +48,6 @@ const useCodes = () => {
     setCodes((prevCodes) => [...prevCodes, ...newCodes]);
   }, [searchText]);
 
-  return { codes, error, hasData, searchText, isLast, isLoading, changeSearchText, getNextCodes };
+  return { codes, error, searchText, isLast, isLoading, changeSearchText, getNextCodes };
 };
 export default useCodes;

--- a/client/src/pocket/style.css.ts
+++ b/client/src/pocket/style.css.ts
@@ -9,7 +9,7 @@ export const wrapper = style([
   u.flex,
   u.flexColumn,
   u.flexAlignCenter,
-  { margin: '0 auto', width: rem(700) },
+  { margin: '0 auto', width: rem(700), paddingBottom: rem(100) },
   m.medium({
     width: '90%',
   }),

--- a/client/src/shared/components/Modal/style.css.ts
+++ b/client/src/shared/components/Modal/style.css.ts
@@ -27,7 +27,7 @@ const scaleDown = keyframes({
 });
 
 export const modalContainer = recipe({
-  base: [u.flexCenter, u.fixedPos, u.top0, u.left0, u.fullSize],
+  base: [u.flexCenter, u.fixedPos, u.top0, u.left0, u.fullSize, { zIndex: 100 }],
   variants: {
     isOpen: {
       true: { display: 'flex' },

--- a/client/src/shared/hooks/useCustomMutation.ts
+++ b/client/src/shared/hooks/useCustomMutation.ts
@@ -29,16 +29,13 @@ const useCustomMutation = <Response, Error, Variable, Context = unknown>({
   validator,
   options,
 }: CustomMutationInterface<Response, Error, Variable, Context>) => {
-  const { data, ...others } = useMutation<Response, Error, Variable, Context>(
+  const { data, isSuccess, ...others } = useMutation<Response, Error, Variable, Context>(
     fetcher<Variable>(url, method),
-    {
-      ...options,
-    },
+    { ...options },
   );
 
-  // if (!validator(data)) throw new Error('에러 발생');
-  if (!validator(data)) return { data, ...others };
-  return { data, ...others };
+  if (!validator(data) && isSuccess) throw new Error('error');
+  return { data, isSuccess, ...others };
 };
 
 export default useCustomMutation;

--- a/client/src/shared/hooks/useCustomMutation.ts
+++ b/client/src/shared/hooks/useCustomMutation.ts
@@ -1,6 +1,6 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 
-import { axiosInstance } from '../lib/axios';
+import { APIErrorType, axiosInstance } from '../lib/axios';
 
 export type MethodType = 'POST' | 'DELETE' | 'PUT' | 'UPDATE';
 
@@ -13,7 +13,7 @@ interface CustomMutationInterface<Response, Error, Variable, Context> {
   url: string;
   method: MethodType;
   validator: (res: Response | undefined) => res is Response;
-  options?: CustomUseMutationOptions<Response, Error, Variable, Context>;
+  options?: CustomUseMutationOptions<Response, APIErrorType<Error>, Variable, Context>;
 }
 
 const fetcher =
@@ -26,15 +26,15 @@ const fetcher =
 const useCustomMutation = <Response, Error, Variable, Context = unknown>({
   url,
   method,
-  validator,
   options,
 }: CustomMutationInterface<Response, Error, Variable, Context>) => {
-  const { data, isSuccess, ...others } = useMutation<Response, Error, Variable, Context>(
-    fetcher<Variable>(url, method),
-    { ...options },
-  );
+  const { data, isSuccess, ...others } = useMutation<
+    Response,
+    APIErrorType<Error>,
+    Variable,
+    Context
+  >(fetcher<Variable>(url, method), { ...options });
 
-  if (!validator(data) && isSuccess) throw new Error('error');
   return { data, isSuccess, ...others };
 };
 

--- a/client/src/shared/hooks/useCustomQuery.ts
+++ b/client/src/shared/hooks/useCustomQuery.ts
@@ -19,9 +19,14 @@ const fetcher = async <T>({ queryKey }: QueryFunctionContext): Promise<T> => {
   return data;
 };
 
-const useCustomQuery = <Response>({ url, params, options }: CustomQueryInterface<Response>) => {
+const useCustomQuery = <Response>({
+  url,
+  params,
+  validator,
+  options,
+}: CustomQueryInterface<Response>) => {
   const commonOptions: QueryOptions<Response> = { staleTime: 1000000, cacheTime: 1000000 };
-  return useQuery<Response, Error, Response, QueryKey>(
+  const { data, ...others } = useQuery<Response, Error, Response, QueryKey>(
     [url!, params],
     ({ queryKey, meta }) => fetcher({ queryKey, meta }),
     {
@@ -29,6 +34,8 @@ const useCustomQuery = <Response>({ url, params, options }: CustomQueryInterface
       ...options,
     },
   );
+  if (!validator(data)) throw new Error('error');
+  return { data, ...others };
 };
 
 export default useCustomQuery;

--- a/client/src/shared/hooks/useCustomQuery.ts
+++ b/client/src/shared/hooks/useCustomQuery.ts
@@ -1,8 +1,11 @@
 import { QueryFunctionContext, QueryKey, useQuery, UseQueryOptions } from '@tanstack/react-query';
 
-import { axiosInstance } from '../lib/axios';
+import { APIErrorType, axiosInstance } from '../lib/axios';
 
-type QueryOptions<Response> = Omit<UseQueryOptions<Response, Error, Response, QueryKey>, ''> & {
+type QueryOptions<Response> = Omit<
+  UseQueryOptions<Response, APIErrorType, Response, QueryKey>,
+  ''
+> & {
   initialData?: () => undefined;
 };
 
@@ -19,14 +22,9 @@ const fetcher = async <T>({ queryKey }: QueryFunctionContext): Promise<T> => {
   return data;
 };
 
-const useCustomQuery = <Response>({
-  url,
-  params,
-  validator,
-  options,
-}: CustomQueryInterface<Response>) => {
+const useCustomQuery = <Response>({ url, params, options }: CustomQueryInterface<Response>) => {
   const commonOptions: QueryOptions<Response> = { staleTime: 1000000, cacheTime: 1000000 };
-  const { data, isFetched, ...others } = useQuery<Response, Error, Response, QueryKey>(
+  const { data, ...others } = useQuery<Response, APIErrorType, Response, QueryKey>(
     [url!, params],
     ({ queryKey, meta }) => fetcher({ queryKey, meta }),
     {
@@ -35,8 +33,7 @@ const useCustomQuery = <Response>({
     },
   );
 
-  if (!validator(data) && !isFetched) throw new Error('error');
-  return { data, isFetched, ...others };
+  return { data, ...others };
 };
 
 export default useCustomQuery;

--- a/client/src/shared/hooks/useCustomQuery.ts
+++ b/client/src/shared/hooks/useCustomQuery.ts
@@ -26,7 +26,7 @@ const useCustomQuery = <Response>({
   options,
 }: CustomQueryInterface<Response>) => {
   const commonOptions: QueryOptions<Response> = { staleTime: 1000000, cacheTime: 1000000 };
-  const { data, ...others } = useQuery<Response, Error, Response, QueryKey>(
+  const { data, isFetched, ...others } = useQuery<Response, Error, Response, QueryKey>(
     [url!, params],
     ({ queryKey, meta }) => fetcher({ queryKey, meta }),
     {
@@ -34,8 +34,9 @@ const useCustomQuery = <Response>({
       ...options,
     },
   );
-  if (!validator(data)) throw new Error('error');
-  return { data, ...others };
+
+  if (!validator(data) && !isFetched) throw new Error('error');
+  return { data, isFetched, ...others };
 };
 
 export default useCustomQuery;

--- a/client/src/shared/hooks/useModal.ts
+++ b/client/src/shared/hooks/useModal.ts
@@ -1,19 +1,19 @@
 import { useEffect, useState } from 'react';
 
-interface UseErrorModal {
-  isError: boolean;
+interface UseModal {
+  isOpened: boolean;
 }
 
-const useErrorModal = ({ isError }: UseErrorModal) => {
+const useModal = ({ isOpened }: UseModal) => {
   const [isModalOpened, setIsModalOpened] = useState(false);
 
   const closeModal = () => setIsModalOpened(false);
 
   useEffect(() => {
-    setIsModalOpened(isError);
-  }, [isError]);
+    setIsModalOpened(isOpened);
+  }, [isOpened]);
 
   return { closeModal, isModalOpened };
 };
 
-export default useErrorModal;
+export default useModal;

--- a/client/src/shared/lib/axios.ts
+++ b/client/src/shared/lib/axios.ts
@@ -14,7 +14,7 @@ interface ErrorType<T> extends AxiosResponse {
 
 type NetworkError = ErrorType<{ message: string }>; // 존재하지 않는 경로 등
 type ServerError<T = unknown> = ErrorType<T>; // 서버에서 에러 반환 등
-export type APIErrorType<T> = NetworkError | ServerError<T>;
+export type APIErrorType<T = { message: string }> = NetworkError | ServerError<T>;
 
 const transformResponse = (data: string) => {
   try {

--- a/core/server/src/createStory.ts
+++ b/core/server/src/createStory.ts
@@ -23,7 +23,8 @@ export default async <T, Response>(request: T, modules: CreateStoryType<Response
 
   const storyAuthor = await modules.getUserName({ pocketToken });
 
-  await modules.isStoryExist({ codeId, storyAuthor, storyName });
+  const isStoryExist = await modules.isStoryExist({ codeId, storyAuthor, storyName });
+  if (isStoryExist) throw modules.existStoryErrorFunc;
   const storyId = await modules.createStory({ codeId, storyAuthor, storyName, codes });
 
   return modules.successResponseFunc({ message: '', storyId });

--- a/server/src/dbModule/story.ts
+++ b/server/src/dbModule/story.ts
@@ -4,7 +4,7 @@ import { to } from 'await-to-js';
 import { FastifyInstance } from 'fastify';
 
 import { CustomResponse } from '../utils/responseHandler';
-import { getCodeById } from './code';
+import { getCodeInfoById } from './code';
 
 export const getStories =
   (server: FastifyInstance) =>
@@ -34,7 +34,7 @@ export const getStory =
 export const existStory =
   (server: FastifyInstance) =>
   async ({ codeId, storyAuthor, storyName }: Types.StoryInfoWithCodeId) => {
-    const { codeAuthor, codeName } = await getCodeById(server)({ codeId });
+    const { codeAuthor, codeName } = await getCodeInfoById(server)({ codeId });
     const [err, story] = await to(
       (async () =>
         await server.store.Story.findOne({ codeAuthor, codeName, storyAuthor, storyName }))(),
@@ -46,7 +46,7 @@ export const existStory =
 export const getStoryFullNames =
   (server: FastifyInstance) =>
   async ({ codeId }: Types.CodeId) => {
-    const { codeAuthor, codeName } = await getCodeById(server)({ codeId });
+    const { codeAuthor, codeName } = await getCodeInfoById(server)({ codeId });
     const stories = await getStories(server)({ codeAuthor, codeName });
 
     const storyNames = stories.map(({ storyAuthor, storyName, _id }) => ({
@@ -71,7 +71,7 @@ export const getStoryCodes =
 export const createStory =
   (server: FastifyInstance) =>
   async ({ codeId, storyAuthor, storyName, codes }: Types.StoryInfoWithCode) => {
-    const { codeAuthor, codeName } = await getCodeById(server)({ codeId });
+    const { codeAuthor, codeName } = await getCodeInfoById(server)({ codeId });
     const [createError, story] = await to(
       (async () =>
         await server.store.Story.create({

--- a/server/src/dbModule/story.ts
+++ b/server/src/dbModule/story.ts
@@ -56,7 +56,7 @@ export const getStoryFullNames =
     return storyNames;
   };
 
-export const getStoryCodes =
+export const getStoryCode =
   (server: FastifyInstance) =>
   async ({ storyId }: Types.StoryId) => {
     const [getStoryCodeErr, story] = await to(

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -75,8 +75,8 @@ export default fp(async (server: FastifyInstance, _: FastifyPluginOptions) => {
     responseHandler(
       () =>
         connector.createStory(req, {
-          successResponseFunc: () =>
-            new CustomResponse<Schema.CreateStoryResponse>({ customStatus: 2001 }),
+          successResponseFunc: (body) =>
+            new CustomResponse<Schema.CreateStoryResponse>({ body, customStatus: 2001 }),
           existStoryErrorFunc: new CustomResponse({ customStatus: 4004 }),
           isStoryExist: StoryModule.existStory(server),
           getUserName: UserModule.getAuthorName(server),

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -53,7 +53,7 @@ export default fp(async (server: FastifyInstance, _: FastifyPluginOptions) => {
         connector.getStoryCode(req, {
           successResponseFunc: (body) =>
             new CustomResponse<Schema.GetStoryCodeResponse>({ customStatus: 2001, body }),
-          getStoryCode: StoryModule.getStoryCodes(server),
+          getStoryCode: StoryModule.getStoryCode(server),
         }),
       reply,
     ),

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -53,7 +53,7 @@ export default fp(async (server: FastifyInstance, _: FastifyPluginOptions) => {
         connector.getStoryCode(req, {
           successResponseFunc: (body) =>
             new CustomResponse<Schema.GetStoryCodeResponse>({ customStatus: 2001, body }),
-          getStoryCodes: StoryModule.getStoryCodes(server),
+          getStoryCode: StoryModule.getStoryCodes(server),
         }),
       reply,
     ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1944,7 +1944,7 @@ __metadata:
     "@storybook/testing-library": ^0.0.13
     "@swc/core": ^1.2.218
     "@swc/jest": ^0.2.22
-    "@tanstack/react-query": ^4.0.5
+    "@tanstack/react-query": ^4.1.3
     "@tanstack/react-query-devtools": ^4.0.3
     "@testing-library/react": ^13.3.0
     "@types/babel__core": ^7
@@ -5903,9 +5903,9 @@ __metadata:
   linkType: hard
 
 "@tanstack/query-core@npm:^4.0.0-beta.1":
-  version: 4.0.5
-  resolution: "@tanstack/query-core@npm:4.0.5"
-  checksum: 706251eeb84adf585ae838cd9c8120a42c6baf270ac4b142e8df39b56b9c3bacae749a60e82cca7143971f7420a9503a479187b13dfd216fd489ff22d8f46d3e
+  version: 4.1.3
+  resolution: "@tanstack/query-core@npm:4.1.3"
+  checksum: 8b8ac7c8b26df02707ae529f8a934da26d34e351fe956b7e24b104a96d2bf559c0d02a96ed5831dc5819774f1d171dcf6b89a759a9f37093c04ea013fefd7cbd
   languageName: node
   linkType: hard
 
@@ -5920,9 +5920,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/react-query@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "@tanstack/react-query@npm:4.0.5"
+"@tanstack/react-query@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "@tanstack/react-query@npm:4.1.3"
   dependencies:
     "@tanstack/query-core": ^4.0.0-beta.1
     "@types/use-sync-external-store": ^0.0.3
@@ -5936,7 +5936,7 @@ __metadata:
       optional: true
     react-native:
       optional: true
-  checksum: c555d2dce19a57ba254855f19a06e4968ae21a08d5cd8890635d9771f77d5aef2e889b23a300b25d1e09b52edeb3fdf7b4579679c43cf9449692463a45a689b8
+  checksum: 18baf3c0d1d0c93a2a81e2652409479eadb8d11fe00a6c872ee551d69771f86f01ec18388c6e7a167a2ba771153dfc23a09c712a0539ff8fab9fb243a631f950
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
closes #129 

- validator를 붙히려 하였는데 react-query와 같이 쓰려니 조건문을 걸기가 빡세서 보류했어요
- 에러처리와 자잘한 변경사항들을 리뷰로 남겨놓을게요

- 클라이언트에서 서버의 에러를 받는다면 사용자에게 보여줘요
- pocket page에서 에러가 발생하면 아래와 같이 보여져요
<img width="798" alt="스크린샷 2022-08-15 오전 2 31 23" src="https://user-images.githubusercontent.com/26402298/184548213-852a1b97-e23e-448a-8741-99007dc3efc3.png">


- pocket page에서 로딩중일 때 좀 더 자연스럽게 보이도록 skeleton으로 바꾸었어요
<img width="1173" alt="스크린샷 2022-08-15 오전 2 24 20" src="https://user-images.githubusercontent.com/26402298/184548191-0b7b35f3-d983-4b0b-acdc-f2830d9869d6.png">

- detail page에서 에러가 발생하면 아래와 같이 보여져요
<img width="1787" alt="스크린샷 2022-08-15 오전 2 26 29" src="https://user-images.githubusercontent.com/26402298/184548202-52eba82c-31bd-4921-b3dc-373ee8e804ca.png">

