### PR TITLE
클라이언트 정규식 수정

### DIFF
--- a/client/src/detail/utils/parse.ts
+++ b/client/src/detail/utils/parse.ts
@@ -1,5 +1,7 @@
-const dependencyRegex = /(?<=import.+(from.+'|')).+(?=')/g;
-export const getDependenciesFromText = (text: string) => [...(text.match(dependencyRegex) || [])];
+const dependencyRegex =
+  /import([ \n\t]*(?:[^ \n\t]+[ \n\t]*,?)?(?:[ \n\t]*(?:[ \n\t]*[^ \n\t"']+[ \n\t]*,?)+)?[ \n\t]*)from[ \n\t]*(['"])([^'"\n]+)(?:['"])/g;
+export const getDependenciesFromText = (text: string) =>
+  [...(text.match(dependencyRegex) || [])].map((dependency) => dependency.split("'")[1]);
 
 export const removeExtension = (filename: string) => filename.split('.')[0];
 


### PR DESCRIPTION
closes #14 

- 까먹고 있다가 이제서야 고쳐서 올립니당
- 기존에 크롬, 사파리에서 지원안되는 `전방탐색`과 `후방탐색`을 없애주었어요.
  - 정규식은 [스택플로우답변](https://stackoverflow.com/questions/52086611/regex-for-matching-js-import-statements)을 참고했어요
  - import문을 찾아서 split으로 쪼개서 가져오는 방식이에요