### PR TITLE
클라이언트 스토리 수정 기능 구현

### DIFF
--- a/client/src/detail/components/Sandpack/index.tsx
+++ b/client/src/detail/components/Sandpack/index.tsx
@@ -11,6 +11,7 @@ import {
   filterObjValueWithKey,
   filterObjWithKey,
 } from '../../utils/filterObj';
+import getAllCodesFromSandpack from '../../utils/getAllCodesFromSandpack';
 import { getDependenciesFromText } from '../../utils/parse';
 import { genrateBaseCode } from '../../utils/textGenerator';
 import * as style from './style.css';
@@ -45,20 +46,12 @@ interface SandpackWrapperProps {
   }) => void;
 }
 
-const ROOT_FILE = '/App.tsx';
 const SandpackComponent: React.FC<SandpackComponentProps> = (props) => {
   const {
     sandpack: { files },
   } = Sandpack.useSandpack();
   const [storyName, setStoryName] = useState('');
   const [isModalOpened, setIsModalOpened] = useState(false);
-
-  const getAllCodes = () => {
-    const SANDPACK_FILE_CODE = 'code';
-    const storyNames = [ROOT_FILE, `/${props.codeName}`];
-    const codes = filterObjValueWithKey(filterObjWithKey(files, storyNames), SANDPACK_FILE_CODE);
-    return codes;
-  };
 
   const changeStoryName = (event: React.ChangeEvent<HTMLInputElement>) => {
     setStoryName(event.target.value);
@@ -74,7 +67,7 @@ const SandpackComponent: React.FC<SandpackComponentProps> = (props) => {
   const closeModal = () => setIsModalOpened(false);
   const onCancel = () => closeModal();
   const onConfirm = () => {
-    const codes = getAllCodes();
+    const codes = getAllCodesFromSandpack({ files, codeName: props.codeName });
     props.pushCode({ codes, storyName });
     setStoryName('');
     closeModal();

--- a/client/src/detail/components/Sandpack/index.tsx
+++ b/client/src/detail/components/Sandpack/index.tsx
@@ -35,7 +35,7 @@ interface SandpackWrapperProps {
   codeName: string;
   codeAuthor: string;
   code: string;
-  selectedStory?: SelectedStory;
+  selectedStoryCodes?: SelectedStory;
   pushCode: ({
     codes,
     storyName,
@@ -112,30 +112,12 @@ const SandpackComponent: React.FC<SandpackComponentProps> = (props) => {
 };
 
 const SandpackWrapper: React.FC<SandpackWrapperProps> = (props) => {
-  const VERSION = 'latest';
-  const dependencies = createObjWithCertainValue(
-    getDependenciesFromText(props?.code || ''),
-    VERSION,
-  );
-  const files = {
-    [ROOT_FILE]: genrateBaseCode(props.codeName),
-    [`/${props.codeName}`]: props?.code || '',
-    ...props.selectedStory?.codes,
-  };
-
   return (
-    <Sandpack.SandpackProvider
-      theme={theme.aquaBlue}
-      template="react-ts"
-      customSetup={{ dependencies }}
-      files={files}
-    >
-      <SandpackComponent
-        codeName={props.codeName}
-        pushCode={props.pushCode}
-        isStory={!!props.selectedStory}
-      />
-    </Sandpack.SandpackProvider>
+    <SandpackComponent
+      codeName={props.codeName}
+      pushCode={props.pushCode}
+      isStory={!!props.selectedStoryCodes}
+    />
   );
 };
 

--- a/client/src/detail/components/StoryNameList/index.tsx
+++ b/client/src/detail/components/StoryNameList/index.tsx
@@ -5,7 +5,7 @@ import React, { useState } from 'react';
 
 import useDeleteStory from '../../hooks/useDeleteStory';
 import useUpdateStory from '../../hooks/useUpdateStory';
-import { filterObjValueWithKey, filterObjWithKey } from '../../utils/filterObj';
+import getAllCodesFromSandpack from '../../utils/getAllCodesFromSandpack';
 import * as style from './style.css';
 
 interface StoryNameListProps {
@@ -21,7 +21,6 @@ interface StoryWantedDelete {
   storyId?: string;
 }
 
-const ROOT_FILE = '/App.tsx';
 const StoryNameList: React.FC<StoryNameListProps> = (props) => {
   const {
     sandpack: { files },
@@ -29,13 +28,6 @@ const StoryNameList: React.FC<StoryNameListProps> = (props) => {
   const [storyWantedDelete, setStoryWantedDelete] = useState<StoryWantedDelete>({ modal: 'none' });
   const { deleteStory } = useDeleteStory({ onSuccessDelete: () => props.selectStory('') });
   const { updateStory } = useUpdateStory();
-
-  const getAllCodes = () => {
-    const SANDPACK_FILE_CODE = 'code';
-    const storyNames = [ROOT_FILE, `/${props.codeName}`];
-    const codes = filterObjValueWithKey(filterObjWithKey(files, storyNames), SANDPACK_FILE_CODE);
-    return codes;
-  };
 
   const onClickDeleteBtn = (event: React.MouseEvent, storyId: string) => {
     event.stopPropagation();
@@ -55,7 +47,8 @@ const StoryNameList: React.FC<StoryNameListProps> = (props) => {
       props.pocketCodes.find((c) => c.storyId === storyId)?.storyName.split('-') || '';
 
     if (modal === 'delete') deleteStory({ codeId: props.codeId, storyAuthor, storyName });
-    else updateStory({ storyId, codes: getAllCodes() });
+    else
+      updateStory({ storyId, codes: getAllCodesFromSandpack({ files, codeName: props.codeName }) });
     closeModal();
   };
 

--- a/client/src/detail/components/StoryNameList/index.tsx
+++ b/client/src/detail/components/StoryNameList/index.tsx
@@ -1,37 +1,67 @@
+import * as Sandpack from '@codesandbox/sandpack-react';
 import { Modal } from '@shared/components';
 import Transition from '@shared/utils/Transition';
 import React, { useState } from 'react';
 
 import useDeleteStory from '../../hooks/useDeleteStory';
+import useUpdateStory from '../../hooks/useUpdateStory';
+import { filterObjValueWithKey, filterObjWithKey } from '../../utils/filterObj';
 import * as style from './style.css';
 
 interface StoryNameListProps {
   codeId: string;
+  codeName: string;
   pocketCodes: { storyName: string; storyId: string }[];
   selectedStoryId?: string;
   selectStory: (storyName: string) => void;
 }
 
-const StoryNameList: React.FC<StoryNameListProps> = (props) => {
-  const [storyWantedDelete, setStoryWantedDelete] = useState('');
-  const { deleteStory } = useDeleteStory({ onSuccessDelete: () => props.selectStory('') });
+interface StoryWantedDelete {
+  modal: 'none' | 'delete' | 'update';
+  storyId?: string;
+}
 
-  const onClickDeleteBtn = (event: React.MouseEvent, storyFullName: string) => {
-    event.stopPropagation();
-    setStoryWantedDelete(storyFullName);
+const ROOT_FILE = '/App.tsx';
+const StoryNameList: React.FC<StoryNameListProps> = (props) => {
+  const {
+    sandpack: { files },
+  } = Sandpack.useSandpack();
+  const [storyWantedDelete, setStoryWantedDelete] = useState<StoryWantedDelete>({ modal: 'none' });
+  const { deleteStory } = useDeleteStory({ onSuccessDelete: () => props.selectStory('') });
+  const { updateStory } = useUpdateStory();
+
+  const getAllCodes = () => {
+    const SANDPACK_FILE_CODE = 'code';
+    const storyNames = [ROOT_FILE, `/${props.codeName}`];
+    const codes = filterObjValueWithKey(filterObjWithKey(files, storyNames), SANDPACK_FILE_CODE);
+    return codes;
   };
 
-  const closeModal = () => setStoryWantedDelete('');
+  const onClickDeleteBtn = (event: React.MouseEvent, storyId: string) => {
+    event.stopPropagation();
+    setStoryWantedDelete({ modal: 'delete', storyId });
+  };
+  const onClickUpdateBtn = (event: React.MouseEvent, storyId: string) => {
+    event.stopPropagation();
+    setStoryWantedDelete({ modal: 'update', storyId });
+  };
+
+  const closeModal = () => setStoryWantedDelete({ modal: 'none' });
   const onCancel = () => closeModal();
   const onConfirm = () => {
-    const [storyAuthor, storyName] = storyWantedDelete.split('-');
-    deleteStory({ codeId: props.codeId, storyAuthor, storyName });
+    const { storyId, modal } = storyWantedDelete;
+    if (!storyId || modal === 'none') return;
+    const [storyAuthor, storyName] =
+      props.pocketCodes.find((c) => c.storyId === storyId)?.storyName.split('-') || '';
+
+    if (modal === 'delete') deleteStory({ codeId: props.codeId, storyAuthor, storyName });
+    else updateStory({ storyId, codes: getAllCodes() });
     closeModal();
   };
 
   return (
     <>
-      <Modal isOpen={!!storyWantedDelete} closeModal={closeModal}>
+      <Modal isOpen={storyWantedDelete.modal !== 'none'} closeModal={closeModal}>
         <p className={style.modalParagraph}>정말로 스토리를 삭제하시겠어요?</p>
         <div className={style.buttonWrapper}>
           <Modal.CancelButton onCancel={onCancel} />
@@ -48,10 +78,15 @@ const StoryNameList: React.FC<StoryNameListProps> = (props) => {
                     selected: props.selectedStoryId === storyId,
                   })}
                 >
-                  <button className={style.modifyButton}>수정</button>
+                  <button
+                    className={style.modifyButton}
+                    onClick={(event) => onClickUpdateBtn(event, storyId)}
+                  >
+                    수정
+                  </button>
                   <button
                     className={style.deleteButton}
-                    onClick={(event) => onClickDeleteBtn(event, storyName)}
+                    onClick={(event) => onClickDeleteBtn(event, storyId)}
                   >
                     삭제
                   </button>

--- a/client/src/detail/components/StoryNameList/index.tsx
+++ b/client/src/detail/components/StoryNameList/index.tsx
@@ -1,5 +1,5 @@
 import * as Sandpack from '@codesandbox/sandpack-react';
-import { Modal } from '@shared/components';
+import { Icon, IconButton, Modal } from '@shared/components';
 import Transition from '@shared/utils/Transition';
 import React, { useState } from 'react';
 
@@ -78,18 +78,14 @@ const StoryNameList: React.FC<StoryNameListProps> = (props) => {
                     selected: props.selectedStoryId === storyId,
                   })}
                 >
-                  <button
-                    className={style.modifyButton}
+                  <IconButton
+                    icon={<Icon icon="edit" />}
                     onClick={(event) => onClickUpdateBtn(event, storyId)}
-                  >
-                    수정
-                  </button>
-                  <button
-                    className={style.deleteButton}
+                  />
+                  <IconButton
+                    icon={<Icon icon="delete" />}
                     onClick={(event) => onClickDeleteBtn(event, storyId)}
-                  >
-                    삭제
-                  </button>
+                  />
                 </div>
               )}
             </Transition>

--- a/client/src/detail/components/StoryNameList/style.css.ts
+++ b/client/src/detail/components/StoryNameList/style.css.ts
@@ -47,6 +47,7 @@ export const modifyButton = style([
     width: '50%',
     height: rem(30),
     border: 'none',
+    cursor: 'pointer',
   },
 ]);
 

--- a/client/src/detail/components/StoryNameList/style.css.ts
+++ b/client/src/detail/components/StoryNameList/style.css.ts
@@ -31,7 +31,7 @@ export const controlButtonsWrapper = recipe({
     u.positionAbsolute,
     u.fullWidth,
     u.flex,
-    { top: rem(-30), zIndex: 'auto' },
+    { top: rem(-30), zIndex: 'auto', justifyContent: 'right', gap: rem(5) },
   ],
   variants: {
     selected: {

--- a/client/src/detail/hooks/useStory.ts
+++ b/client/src/detail/hooks/useStory.ts
@@ -6,8 +6,8 @@ import { getStoryCodeUrl } from '../api';
 import { SelectedStory } from '../components/Sandpack';
 
 const useStory = () => {
-  const [selectedStory, setSelectedStory] = useState<SelectedStory>();
   const [selectedStoryId, setSelectedStoryId] = useState<string>('');
+  const [selectedStoryCodes, setSelectedStoryCodes] = useState<SelectedStory>();
   const { refetch: getStory, error } = useCustomQuery<GetStoryCodeResponse>({
     url: getStoryCodeUrl,
     validator: getStoryCodeResponseValidate,
@@ -25,17 +25,17 @@ const useStory = () => {
   };
 
   const getStoryCode = useCallback(async () => {
-    if (!selectedStoryId) return setSelectedStory(undefined);
+    if (!selectedStoryId) return setSelectedStoryCodes(undefined);
 
     const { data } = await getStory();
     const newSelectedStory = { codes: data?.codes || {} };
-    return setSelectedStory(newSelectedStory);
+    return setSelectedStoryCodes(newSelectedStory);
   }, [getStory, selectedStoryId]);
 
   useEffect(() => {
     getStoryCode();
   }, [selectedStoryId]);
 
-  return { selectedStory, error, selectedStoryId, selectStory };
+  return { selectedStoryCodes, error, selectedStoryId, selectStory };
 };
 export default useStory;

--- a/client/src/detail/hooks/useUpdateStory.ts
+++ b/client/src/detail/hooks/useUpdateStory.ts
@@ -1,0 +1,32 @@
+import {
+  UpdateStoryRequest,
+  UpdateStoryResponse,
+  updateStoryResponseValidate,
+} from '@codepocket/schema';
+import useCustomMutation from '@shared/hooks/useCustomMutation';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { getStoryNamesUrl } from '../api';
+
+type UpdateStoryRequestBody = UpdateStoryRequest['body'];
+
+const useUpdateStory = () => {
+  const queryClient = useQueryClient();
+  const { mutate: updateStoryMutate } = useCustomMutation<
+    UpdateStoryResponse,
+    { message: string },
+    UpdateStoryRequestBody
+  >({
+    url: '/story',
+    method: 'PUT',
+    validator: updateStoryResponseValidate,
+    options: {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries([getStoryNamesUrl]);
+      },
+    },
+  });
+  return { updateStory: updateStoryMutate };
+};
+
+export default useUpdateStory;

--- a/client/src/detail/utils/getAllCodesFromSandpack.ts
+++ b/client/src/detail/utils/getAllCodesFromSandpack.ts
@@ -1,0 +1,16 @@
+import { filterObjValueWithKey, filterObjWithKey } from './filterObj';
+
+interface GetAllCodesFromSandpack {
+  files: any;
+  codeName: string;
+}
+
+const getAllCodesFromSandpack = ({ files, codeName }: GetAllCodesFromSandpack) => {
+  const ROOT_FILE = '/App.tsx';
+  const SANDPACK_FILE_CODE = 'code';
+  const storyNames = [ROOT_FILE, `/${codeName}`];
+  const codes = filterObjValueWithKey(filterObjWithKey(files, storyNames), SANDPACK_FILE_CODE);
+  return codes;
+};
+
+export default getAllCodesFromSandpack;

--- a/client/src/shared/components/IconButton/index.tsx
+++ b/client/src/shared/components/IconButton/index.tsx
@@ -1,10 +1,11 @@
 import { Icon } from '@shared/components';
+import React from 'react';
 
 import * as style from './style.css';
 
 interface IconButtonInterface {
   icon: ReturnType<typeof Icon>;
-  onClick?: () => void;
+  onClick?: (event: React.MouseEvent) => void;
 }
 
 /**

--- a/core/server/src/types/index.ts
+++ b/core/server/src/types/index.ts
@@ -42,7 +42,7 @@ export interface StoryInfo extends CodeInfo {
 
 export interface StoryIdWithCode {
   storyId: string;
-  code: string;
+  codes: { [x: string]: string };
 }
 
 export interface StoryNamesWithCodeId {

--- a/core/server/src/updateStory.ts
+++ b/core/server/src/updateStory.ts
@@ -17,12 +17,12 @@ export interface UpdateStoryType<Response> {
 
 export default async <T, Response>(request: T, modules: UpdateStoryType<Response>) => {
   if (!updateStoryRequestValidate(request)) throw modules.validateError;
-  const { storyId, code } = request.body;
+  const { storyId, codes } = request.body;
 
   const existStory = await modules.isStoryExist({ storyId });
   if (!existStory) throw modules.existStoryErrorFunc();
 
-  await modules.updateStory({ code, storyId });
+  await modules.updateStory({ codes, storyId });
 
   return modules.successResponseFunc({ message: '' });
 };

--- a/schema/json/updateStoryRequest.json
+++ b/schema/json/updateStoryRequest.json
@@ -16,9 +16,14 @@
         }
       },
       "additionalProperties": false,
-      "required": ["storyId", "codes"]
+      "required": [
+        "storyId",
+        "codes"
+      ]
     }
   },
   "additionalProperties": true,
-  "required": ["body"]
+  "required": [
+    "body"
+  ]
 }

--- a/schema/json/updateStoryRequest.json
+++ b/schema/json/updateStoryRequest.json
@@ -5,26 +5,20 @@
     "body": {
       "type": "object",
       "properties": {
-        "pocketToken": {
-          "type": "string"
-        },
         "storyId": {
           "type": "string"
         },
-        "code": {
-          "type": "string"
+        "codes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false,
-      "required": [
-        "pocketToken",
-        "storyId",
-        "code"
-      ]
+      "required": ["storyId", "codes"]
     }
   },
   "additionalProperties": true,
-  "required": [
-    "body"
-  ]
+  "required": ["body"]
 }

--- a/server/src/dbModule/story.ts
+++ b/server/src/dbModule/story.ts
@@ -33,9 +33,10 @@ export const getStory =
 
 export const updateStory =
   (server: FastifyInstance) =>
-  async ({ storyId, code }: Types.StoryIdWithCode) => {
+  async ({ storyId, codes }: Types.StoryIdWithCode) => {
     const [err] = await to(
-      (async () => await server.store.Story.findByIdAndUpdate(storyId, { code }))(),
+      (async () =>
+        await server.store.Story.findByIdAndUpdate(storyId, { codes: JSON.stringify(codes) }))(),
     );
 
     if (err) throw new CustomResponse({ customStatus: 5000 });
@@ -49,6 +50,14 @@ export const existStory =
       (async () =>
         await server.store.Story.findOne({ codeAuthor, codeName, storyAuthor, storyName }))(),
     );
+    if (err) throw new CustomResponse({ customStatus: 5000 });
+    return !!story;
+  };
+
+export const existStoryWithStoryId =
+  (server: FastifyInstance) =>
+  async ({ storyId }: Types.StoryId) => {
+    const [err, story] = await to((async () => await server.store.Story.findById(storyId))());
     if (err) throw new CustomResponse({ customStatus: 5000 });
     return !!story;
   };

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -87,7 +87,7 @@ export default fp(async (server: FastifyInstance, _: FastifyPluginOptions) => {
           successResponseFunc: () =>
             new CustomResponse<Schema.UpdateStoryResponse>({ customStatus: 2009 }),
           existStoryErrorFunc: () => new CustomResponse({ customStatus: 4002 }),
-          isStoryExist: StoryModule.existStory(server),
+          isStoryExist: StoryModule.existStoryWithStoryId(server),
           updateStory: StoryModule.updateStory(server),
         }),
       reply,


### PR DESCRIPTION
closes #156 

- 클라이언트에서 스토리를 수정할 수 있는 기능을 구현했어요
- 기존 버튼에서 만들어주신 icon button을 사용했어요
- 모달은 추후에 통합될 예정이예요

![수정 gif](https://user-images.githubusercontent.com/26402298/185533008-de272bc4-9ef3-4f3a-b321-6559817587c0.gif)

