### PR TITLE
client 생성 모달 구현

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -19,12 +19,12 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <BrowserRouter>
       <Auth0Provider domain={AUTH0_DOMAIN} clientId={AUTH0_CLIENT_ID}>
-        <ModalProvider>
-          <QueryClientProvider client={queryClient}>
+        <QueryClientProvider client={queryClient}>
+          <ModalProvider>
             <App />
             {isDev && <ReactQueryDevtools initialIsOpen={false} />}
-          </QueryClientProvider>
-        </ModalProvider>
+          </ModalProvider>
+        </QueryClientProvider>
       </Auth0Provider>
     </BrowserRouter>
   </React.StrictMode>,

--- a/client/src/pocket/components/Codeblock/index.tsx
+++ b/client/src/pocket/components/Codeblock/index.tsx
@@ -1,6 +1,6 @@
 import { colors } from '@karrotmarket/design-token';
 import { Icon, IconButton } from '@shared/components';
-import { modals } from '@shared/components/GlobalModal';
+import { modals } from '@shared/contexts/GlobalModal';
 import useClipboard from '@shared/hooks/useClipboard';
 import { localStorage } from '@shared/utils/localStorage';
 import { useCallback, useMemo, useRef, useState } from 'react';

--- a/client/src/pocket/components/CreateModal/index.tsx
+++ b/client/src/pocket/components/CreateModal/index.tsx
@@ -1,20 +1,96 @@
+import * as Sandpack from '@codesandbox/sandpack-react';
+import { useActiveCode } from '@codesandbox/sandpack-react';
 import { Modal } from '@shared/components';
 import type { ModalInterface } from '@shared/contexts/ModalContext';
+import { localStorage } from '@shared/utils/localStorage';
+import { rem } from 'polished';
+import React, { useState } from 'react';
 
+import useCreateCode from '../../hooks/useCreateCode';
 import * as style from './style.css';
 
-const CreateModal = ({ closeModal, targetId }: ModalInterface) => {
-  const editCode = () => {
-    console.log(targetId);
+interface ModalContentProps {
+  closeModal?: () => void;
+}
+
+const ModalContent = ({ closeModal }: ModalContentProps) => {
+  const { code } = useActiveCode();
+  const [codeName, setCodeName] = useState('');
+  const [useAnonymousMode, setUseAnonymousMode] = useState(true);
+  const { createCode } = useCreateCode();
+
+  const onConfirm = () => {
+    if (!closeModal) return;
+    createCode({
+      code,
+      codeName,
+      isAnonymous: useAnonymousMode,
+      pocketToken: localStorage.getUserToken() || '',
+    });
+    closeModal();
   };
 
+  const onChangeAnonymousToggle = (event: React.ChangeEvent<HTMLInputElement>) =>
+    setUseAnonymousMode(event.target.checked);
+  const onChangeCodeName = (event: React.ChangeEvent<HTMLInputElement>) =>
+    setCodeName(event.target.value);
+
   return (
-    <div className={style.editModalContainer}>
-      <h1 className={style.editModalHeaderText}>수정할 내용을 입력해주세요</h1>
-      <div className={style.editModalButtonContainer}>
-        <Modal.ConfirmButton text="만들기" onConfirm={editCode} />
+    <div className={style.createModalContent}>
+      <h1 className={style.createModalHeaderText}>새로운 코드 등록하기</h1>
+      <div className={style.createModalHeaderWrapper}>
+        <div style={{ flexGrow: 8 }}>
+          <label className={style.label} htmlFor="codename">
+            코드이름
+          </label>
+          <input
+            autoFocus
+            id="codename"
+            value={codeName}
+            className={style.createModalTitleInput}
+            onChange={onChangeCodeName}
+          />
+        </div>
+        <div>
+          <label className={style.label} htmlFor="title-input">
+            익명
+          </label>
+          <label className={style.toggleSwitch}>
+            <input
+              id="title-input"
+              type="checkbox"
+              className={style.toggleSwitchInput}
+              checked={useAnonymousMode}
+              onChange={onChangeAnonymousToggle}
+            />
+            <span className={style.toggleSwitchSlider}></span>
+          </label>
+        </div>
+      </div>
+      <label className={style.label} htmlFor="code">
+        코드
+      </label>
+      <Sandpack.SandpackLayout style={{ height: '100%' }}>
+        <Sandpack.SandpackCodeEditor id="code" style={{ height: '100%', fontSize: rem(18) }} />
+      </Sandpack.SandpackLayout>
+      <div className={style.createModalButtonContainer}>
+        <Modal.ConfirmButton text="만들기" onConfirm={onConfirm} />
         <Modal.CancelButton text="닫기" onCancel={closeModal} />
       </div>
+    </div>
+  );
+};
+
+const CreateModal = ({ closeModal }: ModalInterface) => {
+  return (
+    <div className={style.createModalContainer}>
+      <Sandpack.SandpackProvider
+        template="react-ts"
+        files={{ '/App.tsx': '' }}
+        style={{ height: '100%' }}
+      >
+        <ModalContent closeModal={closeModal} />
+      </Sandpack.SandpackProvider>
     </div>
   );
 };

--- a/client/src/pocket/components/CreateModal/index.tsx
+++ b/client/src/pocket/components/CreateModal/index.tsx
@@ -1,0 +1,22 @@
+import { Modal } from '@shared/components';
+import type { ModalInterface } from '@shared/contexts/ModalContext';
+
+import * as style from './style.css';
+
+const CreateModal = ({ closeModal, targetId }: ModalInterface) => {
+  const editCode = () => {
+    console.log(targetId);
+  };
+
+  return (
+    <div className={style.editModalContainer}>
+      <h1 className={style.editModalHeaderText}>수정할 내용을 입력해주세요</h1>
+      <div className={style.editModalButtonContainer}>
+        <Modal.ConfirmButton text="만들기" onConfirm={editCode} />
+        <Modal.CancelButton text="닫기" onCancel={closeModal} />
+      </div>
+    </div>
+  );
+};
+
+export default CreateModal;

--- a/client/src/pocket/components/CreateModal/style.css.ts
+++ b/client/src/pocket/components/CreateModal/style.css.ts
@@ -1,4 +1,5 @@
 import { vars } from '@seed-design/design-token';
+import * as m from '@shared/styles/media.css';
 import * as t from '@shared/styles/token.css';
 import * as u from '@shared/styles/utils.css';
 import { style } from '@vanilla-extract/css';
@@ -6,7 +7,10 @@ import { rem } from 'polished';
 
 export const label = style([{ display: 'block', fontSize: rem(18) }]);
 
-export const createModalContainer = style([{ width: rem(700), height: '90vh' }]);
+export const createModalContainer = style([
+  { width: rem(700), height: '70vh' },
+  m.medium({ width: '100vw', height: '100vh', padding: rem(10) }),
+]);
 
 export const createModalTitleInput = style([
   u.border,

--- a/client/src/pocket/components/CreateModal/style.css.ts
+++ b/client/src/pocket/components/CreateModal/style.css.ts
@@ -1,9 +1,87 @@
+import { vars } from '@seed-design/design-token';
+import * as t from '@shared/styles/token.css';
 import * as u from '@shared/styles/utils.css';
 import { style } from '@vanilla-extract/css';
 import { rem } from 'polished';
 
-export const editModalContainer = style([u.flexColumn, { rowGap: rem(10) }]);
+export const label = style([{ display: 'block', fontSize: rem(18) }]);
 
-export const editModalButtonContainer = style([u.flex, { columnGap: rem(10) }]);
+export const createModalContainer = style([{ width: rem(700), height: '90vh' }]);
 
-export const editModalHeaderText = style({ fontSize: rem(20) });
+export const createModalTitleInput = style([
+  u.border,
+  u.fullWidth,
+  u.borderRadius2,
+  {
+    outline: 'none',
+    height: rem(34),
+    fontSize: rem(16),
+    paddingLeft: rem(15),
+  },
+]);
+
+export const createModalContent = style([
+  u.flexColumn,
+  u.fullHeight,
+  { rowGap: rem(10), justifyContent: 'space-around' },
+]);
+
+export const createModalButtonContainer = style([u.flex, { columnGap: rem(10) }]);
+
+export const createModalHeaderWrapper = style([u.flex, { gap: rem(10) }]);
+
+export const createModalHeaderText = style([t.typography.heading4]);
+
+export const toggleSwitch = style([
+  { position: 'relative', display: 'inline-block', width: rem(60), height: rem(34) },
+]);
+
+export const toggleSwitchInput = style({
+  opacity: 0,
+  width: 0,
+  height: 0,
+});
+
+export const toggleSwitchSlider = style([
+  u.cursorPointer,
+  u.positionAbsolute,
+  {
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: '#ccc',
+    transition: '0.3s',
+    borderRadius: rem(6),
+
+    ':before': {
+      content: '',
+      position: 'absolute',
+      height: rem(26),
+      width: rem(26),
+      left: rem(4),
+      bottom: rem(4),
+      backgroundColor: vars.$static.color.staticWhite,
+      transition: '0.3s',
+      borderRadius: rem(6),
+    },
+
+    selectors: {
+      [`${toggleSwitchInput}:checked + &`]: {
+        backgroundColor: `${vars.$scale.color.blue600}`,
+      },
+
+      [`${toggleSwitchInput}:checked:hover + &`]: {
+        backgroundColor: `${vars.$scale.color.blue400}`,
+      },
+
+      [`${toggleSwitchInput}:checked + &:before`]: {
+        transform: `translateX(26px)`,
+      },
+
+      [`${toggleSwitchInput}:focus + &`]: {
+        boxShadow: `0 0 1px ${vars.$scale.color.blue600}`,
+      },
+    },
+  },
+]);

--- a/client/src/pocket/components/CreateModal/style.css.ts
+++ b/client/src/pocket/components/CreateModal/style.css.ts
@@ -1,0 +1,9 @@
+import * as u from '@shared/styles/utils.css';
+import { style } from '@vanilla-extract/css';
+import { rem } from 'polished';
+
+export const editModalContainer = style([u.flexColumn, { rowGap: rem(10) }]);
+
+export const editModalButtonContainer = style([u.flex, { columnGap: rem(10) }]);
+
+export const editModalHeaderText = style({ fontSize: rem(20) });

--- a/client/src/pocket/components/FloatingActionButton/index.tsx
+++ b/client/src/pocket/components/FloatingActionButton/index.tsx
@@ -13,16 +13,19 @@ const FloatingActionButton: React.FC<FloatingButtonProps> = () => {
   const modalDispatch = useModalDispatch();
   const { scrollDir } = useScrollDirection();
 
-  const toggleButton = () => {
-    if (!selected) modalDispatch({ type: 'OPEN_MODAL', Component: CreateModal });
-    setSelected((prev) => !prev);
+  const toggleButton = () => setSelected((prev) => !prev);
+
+  const onClickButton = () => {
+    toggleButton();
+    if (!selected)
+      modalDispatch({ type: 'OPEN_MODAL', Component: CreateModal, closeModal: toggleButton });
   };
 
   return (
     <Transition isOn={scrollDir === 'up'} timeout={300}>
       {() => (
         <div className={style.wrapper({ useOnMode: scrollDir === 'up' })}>
-          <button className={style.floatingButton({ selected })} onClick={toggleButton}>
+          <button className={style.floatingButton({ selected })} onClick={onClickButton}>
             +
           </button>
         </div>

--- a/client/src/pocket/components/FloatingActionButton/index.tsx
+++ b/client/src/pocket/components/FloatingActionButton/index.tsx
@@ -1,16 +1,22 @@
+import { useModalDispatch } from '@shared/contexts/ModalContext';
 import Transition from '@shared/utils/Transition';
 import { useState } from 'react';
 
 import useScrollDirection from '../../hooks/useScrollDirection';
+import CreateModal from '../CreateModal';
 import * as style from './style.css';
 
 interface FloatingButtonProps {}
 
 const FloatingActionButton: React.FC<FloatingButtonProps> = () => {
   const [selected, setSelected] = useState(false);
+  const modalDispatch = useModalDispatch();
   const { scrollDir } = useScrollDirection();
 
-  const toggleButton = () => setSelected((prev) => !prev);
+  const toggleButton = () => {
+    if (!selected) modalDispatch({ type: 'OPEN_MODAL', Component: CreateModal });
+    setSelected((prev) => !prev);
+  };
 
   return (
     <Transition isOn={scrollDir === 'up'} timeout={300}>

--- a/client/src/pocket/hooks/useCreateCode.ts
+++ b/client/src/pocket/hooks/useCreateCode.ts
@@ -1,0 +1,27 @@
+import { PushCodeRequest, PushCodeResponse, pushCodeResponseValidate } from '@codepocket/schema';
+import useCustomMutation from '@shared/hooks/useCustomMutation';
+import { useQueryClient } from '@tanstack/react-query';
+
+type PushCodeBodyType = PushCodeRequest['body'];
+
+const useCreateCode = () => {
+  const queryClient = useQueryClient();
+  const { mutate: createCodeMutate } = useCustomMutation<
+    PushCodeResponse,
+    { message: string },
+    PushCodeBodyType
+  >({
+    url: '/code',
+    method: 'POST',
+    validator: pushCodeResponseValidate,
+    options: {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries([]);
+      },
+    },
+  });
+
+  return { createCode: createCodeMutate };
+};
+
+export default useCreateCode;

--- a/client/src/shared/components/Modal/style.css.ts
+++ b/client/src/shared/components/Modal/style.css.ts
@@ -65,9 +65,6 @@ export const modalContent = recipe({
     u.flexColumn,
     u.borderRadius2,
     {
-      width: rem(375),
-      minHeight: rem(37.5),
-      // height: 'auto',
       backgroundColor: 'white',
       padding: rem(15),
       zIndex: MODAL_Z_INDEX,
@@ -120,7 +117,7 @@ const modalBaseButton = style([
     height: rem(45),
     fontSize: rem(14),
     backgroundColor: colors.light.scheme.$blue800,
-    color: 'white',
+    color: vars.$static.color.staticWhite,
     fontWeight: 'bold',
     transition: 'background 0.2s ease',
 

--- a/client/src/shared/components/index.tsx
+++ b/client/src/shared/components/index.tsx
@@ -1,6 +1,5 @@
 export { default as Alert } from './Alert';
 export { default as AsyncBoundary } from './AsyncBoundary';
-export { default as GlobalModal } from './GlobalModal';
 export { default as Icon } from './Icon';
 export { default as IconButton } from './IconButton';
 export { default as Modal } from './Modal';

--- a/client/src/shared/contexts/GlobalModal.tsx
+++ b/client/src/shared/contexts/GlobalModal.tsx
@@ -2,8 +2,8 @@ import Modal from '@shared/components/Modal';
 import { useModalDispatch, useModalState } from '@shared/contexts/ModalContext';
 import { useCallback } from 'react';
 
-import DeleteModal from '../../../pocket/components/DeleteModal';
-import EditModal from '../../../pocket/components/EditModal';
+import DeleteModal from '../../pocket/components/DeleteModal';
+import EditModal from '../../pocket/components/EditModal';
 
 export const modals = {
   deleteModal: DeleteModal,

--- a/client/src/shared/contexts/GlobalModal.tsx
+++ b/client/src/shared/contexts/GlobalModal.tsx
@@ -15,7 +15,10 @@ const GlobalModal = () => {
   const state = useModalState();
 
   const { ModalComponent, targetId } = state;
-  const closeModal = useCallback(() => dispatch({ type: 'CLOSE_MODAL' }), [dispatch]);
+  const closeModal = useCallback(() => {
+    if (state.closeModal) state.closeModal();
+    dispatch({ type: 'CLOSE_MODAL' });
+  }, [dispatch, state]);
 
   return (
     <Modal isOpen={state.isModalOpen} closeModal={closeModal} disableEscape>

--- a/client/src/shared/contexts/ModalContext.tsx
+++ b/client/src/shared/contexts/ModalContext.tsx
@@ -1,5 +1,6 @@
-import { GlobalModal } from '@shared/components';
 import React, { createContext, Dispatch, useContext, useReducer } from 'react';
+
+import GlobalModal from './GlobalModal';
 
 export interface ModalInterface {
   closeModal?: () => void;

--- a/client/src/shared/contexts/ModalContext.tsx
+++ b/client/src/shared/contexts/ModalContext.tsx
@@ -8,13 +8,14 @@ export interface ModalInterface {
 }
 type Component = (props: ModalInterface) => JSX.Element;
 type State = {
-  ModalComponent: Component | null;
-  isModalOpen: boolean;
   targetId: string;
+  isModalOpen: boolean;
+  ModalComponent: Component | null;
+  closeModal?: () => void;
 };
 
 type Action =
-  | { type: 'OPEN_MODAL'; Component: Component; targetId?: string }
+  | { type: 'OPEN_MODAL'; Component: Component; targetId?: string; closeModal?: () => void }
   | { type: 'CLOSE_MODAL' };
 
 type ModalDispatch = Dispatch<Action>;
@@ -27,16 +28,18 @@ function reducer(state: State, action: Action): State {
     case 'OPEN_MODAL':
       return {
         ...state,
-        ModalComponent: action.Component,
-        isModalOpen: true,
         targetId: action.targetId || '',
+        isModalOpen: true,
+        ModalComponent: action.Component,
+        closeModal: action.closeModal,
       };
     case 'CLOSE_MODAL':
       return {
         ...state,
-        ModalComponent: null,
-        isModalOpen: false,
         targetId: '',
+        isModalOpen: false,
+        ModalComponent: null,
+        closeModal: undefined,
       };
     default:
       throw new Error('Unhandled action');


### PR DESCRIPTION
closes #169 

**다음 PR에 여기 내용이 전부 포함되어있어요. `한 번에 보고 싶으시면 스크린샷과 리뷰는 이것만 보시고 다음 PR보시면 돼요`. 양이 많다 싶으면 이 PR리뷰하고 요청하시면 수정본 합쳐서 다음 PR에 붙힐게요.**

- 생성하기 모달을 구현했어요

<img width="1791" alt="스크린샷 2022-08-22 오후 2 34 28" src="https://user-images.githubusercontent.com/26402298/185846526-59cfba70-6bfd-43df-b77f-ed928338d822.png">

## 논의
- 저희가 입력 화면이 아니라 모달을 띄우는데, 전체적으로 띄우는게 좋을까요 아니면 모달처럼 뜨는게 좋을까요?
  - 이쪽으로 입력을 할 일은 많지 않겠지만 넓은게 좀 더 입력하기 좋을 것 같아 우선 전체적으로 하긴했는데, 이런식으로 뜨는 경우는 잘 보지 못해서 의견 구해요
![모바일](https://user-images.githubusercontent.com/26402298/185846241-3e44ce0d-f608-4651-b622-0e12f7768fa8.gif)

