### PR TITLE
seed-design/token으로 마이그레이션

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,6 @@
     "@codepocket/schema": "^0.0.4",
     "@codesandbox/sandpack-react": "^1.2.4",
     "@codesandbox/sandpack-themes": "^1.0.0",
-    "@karrotmarket/design-token": "^1.1.2",
     "@seed-design/design-token": "^1.0.0-alpha.0",
     "@seed-design/stylesheet": "^1.0.0-beta.1",
     "@tanstack/react-query": "^4.1.3",

--- a/client/src/auth/components/SubTitle/style.css.ts
+++ b/client/src/auth/components/SubTitle/style.css.ts
@@ -1,4 +1,4 @@
-import { colors } from '@karrotmarket/design-token';
+import { vars } from '@seed-design/design-token';
 import * as m from '@shared/styles/media.css';
 import * as u from '@shared/styles/utils.css';
 import { style } from '@vanilla-extract/css';
@@ -7,7 +7,7 @@ import { rem } from 'polished';
 export const subtitle = style([
   u.positionRelative,
   {
-    color: colors.light.scheme.$gray900,
+    color: vars.$scale.color.gray900,
     fontSize: rem(17),
   },
   m.small({

--- a/client/src/detail/Detail.tsx
+++ b/client/src/detail/Detail.tsx
@@ -1,6 +1,6 @@
 import * as Sandpack from '@codesandbox/sandpack-react';
 import * as theme from '@codesandbox/sandpack-themes';
-import { colors } from '@karrotmarket/design-token';
+import { vars } from '@seed-design/design-token';
 import { Icon, Modal } from '@shared/components';
 import useCode from '@shared/hooks/useCode';
 import useModal from '@shared/hooks/useModal';
@@ -60,7 +60,7 @@ const DetailPage: React.FC = () => {
           <header className={style.header}>
             <div className={style.headerIcon}>
               <Link to={pocketPath}>
-                <Icon icon="leftChevron" color={colors.light.scheme.$blue800} />
+                <Icon icon="leftChevron" color={vars.$scale.color.blue800} />
               </Link>
             </div>
             <h1 className={style.title}>

--- a/client/src/detail/components/Sandpack/style.css.ts
+++ b/client/src/detail/components/Sandpack/style.css.ts
@@ -1,4 +1,4 @@
-import { colors } from '@karrotmarket/design-token';
+import { vars } from '@seed-design/design-token';
 import * as m from '@shared/styles/media.css';
 import * as t from '@shared/styles/token.css';
 import * as u from '@shared/styles/utils.css';
@@ -34,11 +34,11 @@ export const submitButton = recipe({
       height: rem(52),
       fontSize: rem(16),
       display: 'block',
-      color: colors.light.scheme.$white,
+      color: vars.$static.color.staticWhite,
       transition: 'background 0.2s ease',
 
       ':hover': {
-        backgroundColor: '#0A86B766',
+        backgroundColor: vars.$scale.color.blue400,
       },
     },
     m.small({
@@ -48,11 +48,11 @@ export const submitButton = recipe({
   variants: {
     enable: {
       true: {
-        backgroundColor: colors.light.scheme.$blue800,
+        backgroundColor: vars.$scale.color.blue500,
       },
       false: {
         cursor: 'not-allowed',
-        backgroundColor: colors.light.scheme.$blue50,
+        backgroundColor: vars.$scale.color.blue300,
       },
     },
   },
@@ -76,11 +76,11 @@ export const storyNameInput = recipe({
   variants: {
     enable: {
       true: {
-        backgroundColor: colors.light.scheme.$white,
+        backgroundColor: vars.$static.color.staticWhite,
       },
       false: {
         cursor: 'not-allowed',
-        backgroundColor: colors.light.scheme.$gray100,
+        backgroundColor: vars.$scale.color.gray100,
       },
     },
   },

--- a/client/src/detail/components/SandpackLoader/style.css.ts
+++ b/client/src/detail/components/SandpackLoader/style.css.ts
@@ -1,4 +1,4 @@
-import { colors } from '@karrotmarket/design-token';
+import { vars } from '@seed-design/design-token';
 import * as t from '@shared/styles/token.css';
 import * as u from '@shared/styles/utils.css';
 import { keyframes, style } from '@vanilla-extract/css';
@@ -20,7 +20,7 @@ export const skeletonContainer = style([
 
 export const loader = style({
   border: '16px solid #f3f3f3',
-  borderTop: `16px solid ${colors.light.scheme.$blue800}`,
+  borderTop: `16px solid ${vars.$scale.color.blue700}`,
   borderRadius: '50%',
   width: '120px',
   height: '120px',

--- a/client/src/detail/style.css.ts
+++ b/client/src/detail/style.css.ts
@@ -1,4 +1,4 @@
-import { colors } from '@karrotmarket/design-token';
+import { vars } from '@seed-design/design-token';
 import * as m from '@shared/styles/media.css';
 import * as t from '@shared/styles/token.css';
 import * as u from '@shared/styles/utils.css';
@@ -45,7 +45,7 @@ export const title = style([
 ]);
 
 export const highlight = style({
-  color: colors.light.scheme.$blue800,
+  color: vars.$scale.color.blue800,
   fontWeight: 'normal',
 });
 

--- a/client/src/pocket/components/CodeBlockSkeleton/style.css.ts
+++ b/client/src/pocket/components/CodeBlockSkeleton/style.css.ts
@@ -1,18 +1,18 @@
-import { colors } from '@karrotmarket/design-token';
+import { vars } from '@seed-design/design-token';
 import * as m from '@shared/styles/media.css';
 import * as u from '@shared/styles/utils.css';
 import { keyframes, style } from '@vanilla-extract/css';
 import { rem } from 'polished';
 
 const gradation = keyframes({
-  '0%': { backgroundColor: colors.light.scheme.$gray100 },
-  '50%': { backgroundColor: colors.light.scheme.$gray300 },
-  '100%': { backgroundColor: colors.light.scheme.$gray100 },
+  '0%': { backgroundColor: vars.$scale.color.gray100 },
+  '50%': { backgroundColor: vars.$scale.color.gray300 },
+  '100%': { backgroundColor: vars.$scale.color.gray100 },
 });
 
 export const gradationAnim = style([
   {
-    backgroundColor: colors.light.scheme.$gray100,
+    backgroundColor: vars.$scale.color.gray100,
     animation: `2s infinite ${gradation}`,
   },
 ]);

--- a/client/src/pocket/components/CodeList/style.css.ts
+++ b/client/src/pocket/components/CodeList/style.css.ts
@@ -1,4 +1,4 @@
-import { colors } from '@karrotmarket/design-token';
+import { vars } from '@seed-design/design-token';
 import * as u from '@shared/styles/utils.css';
 import { style } from '@vanilla-extract/css';
 import { rem } from 'polished';
@@ -17,6 +17,6 @@ export const lastCodeItemInformation = style([
   u.flexCenter,
   {
     rowGap: rem(10),
-    color: colors.light.scheme.$gray700,
+    color: vars.$scale.color.gray700,
   },
 ]);

--- a/client/src/pocket/components/Codeblock/index.tsx
+++ b/client/src/pocket/components/Codeblock/index.tsx
@@ -1,4 +1,4 @@
-import { colors } from '@karrotmarket/design-token';
+import { vars } from '@seed-design/design-token';
 import { Icon, IconButton } from '@shared/components';
 import { modals } from '@shared/contexts/GlobalModal';
 import useClipboard from '@shared/hooks/useClipboard';
@@ -97,7 +97,7 @@ const Codeblock: React.FC<CodeblockProps> = ({
             className={style.codeItemHeaderCopyButton}
             onClick={copyToClipboard}
           >
-            {isCopied ? 'COPIED!' : 'COPY'}
+            {isCopied ? 'COPIED' : 'COPY'}
           </button>
           <a href={generateDetailPath({ codeId })}>
             <button
@@ -107,7 +107,7 @@ const Codeblock: React.FC<CodeblockProps> = ({
             >
               <span>DETAIL</span>
               <span className={style.rightChevronIcon}>
-                <Icon icon="rightChevron" color={colors.light.scheme.$blue800} />
+                <Icon icon="rightChevron" color={vars.$scale.color.blue700} />
               </span>
             </button>
           </a>

--- a/client/src/pocket/components/Codeblock/style.css.ts
+++ b/client/src/pocket/components/Codeblock/style.css.ts
@@ -1,4 +1,4 @@
-import { colors } from '@karrotmarket/design-token';
+import { vars } from '@seed-design/design-token';
 import * as m from '@shared/styles/media.css';
 import * as u from '@shared/styles/utils.css';
 import { style } from '@vanilla-extract/css';
@@ -65,7 +65,7 @@ export const codeItemCode = recipe({
           pointerEvents: 'none',
         },
         ':hover': {
-          border: `1px solid ${colors.light.scheme.$blue800}`,
+          border: `1px solid ${vars.$scale.color.blue700}`,
           cursor: 'pointer',
         },
       },
@@ -98,8 +98,8 @@ export const toggler = style([
 ]);
 
 export const rightChevronIcon = style({
-  color: colors.light.scheme.$blue800,
-  transform: 'scale(0.7)',
+  color: vars.$scale.color.blue700,
+  transform: 'scale(0.5)',
   width: rem(12),
   height: rem(20),
 });
@@ -140,12 +140,13 @@ export const codeItemButtonBase = style([
 export const codeItemHeaderCopyButton = style([
   codeItemButtonBase,
   {
-    width: rem(70),
-    border: `1px solid ${colors.light.scheme.$gray700}`,
-    color: colors.light.scheme.$gray700,
+    width: rem(80),
+    backgroundColor: vars.$scale.color.gray300,
+    color: vars.$scale.color.gray900,
+    border: 'none',
 
     ':hover': {
-      backgroundColor: colors.light.scheme.$gray100,
+      backgroundColor: vars.$scale.color.gray200,
     },
   },
   m.medium({
@@ -156,11 +157,12 @@ export const codeItemHeaderCopyButton = style([
 export const codeItemHeaderDetailButton = style([
   codeItemButtonBase,
   {
-    border: `1px solid ${colors.light.scheme.$blue800}`,
-    color: colors.light.scheme.$blue800,
+    border: 'none',
+    backgroundColor: vars.$scale.color.blue50,
+    color: vars.$scale.color.blue700,
 
     ':hover': {
-      backgroundColor: colors.light.scheme.$blue50,
+      backgroundColor: vars.$scale.color.blue100,
     },
   },
 ]);

--- a/client/src/pocket/components/FloatingActionButton/style.css.ts
+++ b/client/src/pocket/components/FloatingActionButton/style.css.ts
@@ -26,8 +26,12 @@ export const floatingButton = recipe({
       borderRadius: '50%',
       fontSize: 'inherit',
       color: vars.$static.color.staticWhite,
-      backgroundColor: vars.$scale.color.blue600,
+      backgroundColor: vars.$scale.color.blue500,
       transition: `all ${ANIMATION_DURATION_SECOND}s`,
+
+      ':hover': {
+        backgroundColor: vars.$scale.color.blue400,
+      },
     },
   ],
   variants: {

--- a/client/src/pocket/components/MoreButton/style.css.ts
+++ b/client/src/pocket/components/MoreButton/style.css.ts
@@ -1,4 +1,4 @@
-import { colors } from '@karrotmarket/design-token';
+import { vars } from '@seed-design/design-token';
 import * as u from '@shared/styles/utils.css';
 import { style } from '@vanilla-extract/css';
 import { rem } from 'polished';
@@ -14,7 +14,7 @@ export const buttonBase = style([
     height: rem(70),
     margin: rem(30),
     padding: rem(10),
-    border: '1px solid white',
+    border: `1px solid ${vars.$static.color.staticWhite}`,
   },
 ]);
 
@@ -22,12 +22,12 @@ export const moreButton = style([
   buttonBase,
   u.cursorPointer,
   {
-    backgroundColor: colors.light.scheme.$blue50,
-    color: colors.light.scheme.$blue800,
+    backgroundColor: vars.$scale.color.blue100,
+    color: vars.$scale.color.blue700,
 
     ':hover': {
-      border: `1px solid ${colors.light.scheme.$blue800}`,
-      backgroundColor: '#def8ff',
+      border: `1px solid ${vars.$scale.color.blue600}`,
+      backgroundColor: vars.$scale.color.blue200,
     },
   },
 ]);

--- a/client/src/pocket/components/PendingFallback/style.css.ts
+++ b/client/src/pocket/components/PendingFallback/style.css.ts
@@ -1,12 +1,12 @@
-import { colors } from '@karrotmarket/design-token';
+import { vars } from '@seed-design/design-token';
 import * as u from '@shared/styles/utils.css';
 import { keyframes, style } from '@vanilla-extract/css';
 import { rem } from 'polished';
 
 const gradation = keyframes({
-  '0%': { backgroundColor: colors.light.scheme.$gray100 },
-  '50%': { backgroundColor: colors.light.scheme.$gray300 },
-  '100%': { backgroundColor: colors.light.scheme.$gray100 },
+  '0%': { backgroundColor: vars.$scale.color.gray100 },
+  '50%': { backgroundColor: vars.$scale.color.gray300 },
+  '100%': { backgroundColor: vars.$scale.color.gray100 },
 });
 
 export const pendingFallback = style([
@@ -16,7 +16,7 @@ export const pendingFallback = style([
   {
     height: rem(100),
     marginTop: rem(20),
-    backgroundColor: colors.light.scheme.$gray100,
+    backgroundColor: vars.$scale.color.gray100,
     animation: `2s infinite ${gradation}`,
   },
 ]);

--- a/client/src/pocket/components/SearchHelpText/style.css.ts
+++ b/client/src/pocket/components/SearchHelpText/style.css.ts
@@ -1,4 +1,4 @@
-import { colors } from '@karrotmarket/design-token';
+import { vars } from '@seed-design/design-token';
 import * as u from '@shared/styles/utils.css';
 import { style } from '@vanilla-extract/css';
 import { rem } from 'polished';
@@ -15,7 +15,7 @@ export const searchText = style([
   u.borderRadius2,
   {
     padding: rem(4),
-    backgroundColor: colors.light.scheme.$blue50,
+    backgroundColor: vars.$scale.color.blue100,
     fontWeight: 'bold',
   },
 ]);

--- a/client/src/pocket/components/Searchbar/index.tsx
+++ b/client/src/pocket/components/Searchbar/index.tsx
@@ -38,7 +38,9 @@ const Searchbar: React.FC<SearchbarInterface> = ({ changeSearchText }) => {
         placeholder="찾고 싶은 코드나 작성자 이름을 입력해보세요!"
         value={text}
         onChange={onChangeSearchbar}
-        className={style.searchbox}
+        className={style.searchbox({
+          isScrollTop,
+        })}
         autoFocus
       />
       <span className={style.searchicon}>

--- a/client/src/pocket/components/Searchbar/style.css.ts
+++ b/client/src/pocket/components/Searchbar/style.css.ts
@@ -1,4 +1,4 @@
-import { colors } from '@karrotmarket/design-token';
+import { vars } from '@seed-design/design-token';
 import * as u from '@shared/styles/utils.css';
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
@@ -24,24 +24,37 @@ export const container = recipe({
       },
       false: {
         transform: `translateY(${rem(8)})`,
-        border: `2px solid ${colors.light.scheme.$blue800}`,
         height: rem(45),
       },
     },
   },
 });
 
-export const searchbox = style([
-  u.fullWidth,
-  u.fullHeight,
-  u.borderRadius2,
-  u.borderNone,
-  {
-    padding: rem(10),
-    paddingRight: rem(40),
-    backgroundColor: colors.light.scheme.$gray100,
+export const searchbox = recipe({
+  base: [
+    u.fullWidth,
+    u.fullHeight,
+    u.borderRadius2,
+    u.borderNone,
+    {
+      padding: rem(10),
+      paddingRight: rem(40),
+      backgroundColor: vars.$scale.color.gray100,
+
+      ':focus': {
+        outline: 'none',
+        border: `2px solid ${vars.$scale.color.blue500}`,
+      },
+    },
+  ],
+  variants: {
+    isScrollTop: {
+      false: {
+        border: `2px solid ${vars.$scale.color.blue500}`,
+      },
+    },
   },
-]);
+});
 
 export const searchicon = style([
   u.right0,

--- a/client/src/pocket/style.css.ts
+++ b/client/src/pocket/style.css.ts
@@ -1,4 +1,4 @@
-import { colors } from '@karrotmarket/design-token';
+import { vars } from '@seed-design/design-token';
 import * as m from '@shared/styles/media.css';
 import * as t from '@shared/styles/token.css';
 import * as u from '@shared/styles/utils.css';
@@ -9,7 +9,7 @@ export const wrapper = style([
   u.flex,
   u.flexColumn,
   u.flexAlignCenter,
-  { margin: '0 auto', width: rem(700), paddingBottom: rem(100) },
+  { margin: '0 auto', width: rem(700), paddingBottom: rem(40) },
   m.medium({
     width: '90%',
   }),
@@ -41,30 +41,4 @@ export const codeItemHeader = style([
 
 export const codeItemInfo = style([{ fontWeight: 'bold' }]);
 
-export const codeItemCode = style([{ backgroundColor: colors.light.scheme.$gray300 }]);
-
-export const highlight = style({
-  color: colors.light.scheme.$carrot600,
-  fontWeight: 'normal',
-});
-
-export const lastCodeItem = style([
-  u.fullWidth,
-  u.borderRadius2,
-  u.flexCenter,
-  {
-    background: colors.light.scheme.$gray100,
-    height: rem(250),
-    marginTop: rem(60),
-  },
-]);
-
-export const lastCodeItemInformation = style([
-  u.flex,
-  u.flexColumn,
-  u.flexCenter,
-  {
-    rowGap: rem(10),
-    color: colors.light.scheme.$gray700,
-  },
-]);
+export const codeItemCode = style([{ backgroundColor: vars.$scale.color.gray300 }]);

--- a/client/src/shared/components/Alert/index.tsx
+++ b/client/src/shared/components/Alert/index.tsx
@@ -1,4 +1,4 @@
-import { colors } from '@karrotmarket/design-token';
+import { vars } from '@seed-design/design-token';
 import { Icon } from '@shared/components';
 
 import * as style from './style.css';
@@ -10,10 +10,10 @@ interface AlertInterface {
 
 const AlertIcon = ({ status }: Pick<AlertInterface, 'status'>) => {
   const icon = {
-    error: <Icon icon="warningFill" color={colors.light.scheme.$red800} />,
-    info: <Icon icon="information" color={colors.light.scheme.$blue800} />,
-    success: <Icon icon="check" color={colors.light.scheme.$green500} />,
-    warning: <Icon icon="warningFill" color={colors.light.scheme.$carrot600} />,
+    error: <Icon icon="warningFill" color={vars.$scale.color.red700} />,
+    info: <Icon icon="information" color={vars.$scale.color.blue700} />,
+    success: <Icon icon="check" color={vars.$scale.color.green600} />,
+    warning: <Icon icon="warningFill" color={vars.$scale.color.carrot700} />,
   };
   return icon[status];
 };

--- a/client/src/shared/components/Alert/style.css.ts
+++ b/client/src/shared/components/Alert/style.css.ts
@@ -1,4 +1,4 @@
-import { colors } from '@karrotmarket/design-token';
+import { vars } from '@seed-design/design-token';
 import * as u from '@shared/styles/utils.css';
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
@@ -17,10 +17,10 @@ export const alertContainer = recipe({
   ],
   variants: {
     status: {
-      error: { background: colors.light.scheme.$red50 },
-      info: { background: colors.light.scheme.$blue50 },
-      success: { background: colors.light.scheme.$green50 },
-      warning: { background: colors.light.scheme.$carrot100 },
+      error: { background: vars.$scale.color.red100 },
+      info: { background: vars.$scale.color.blue100 },
+      success: { background: vars.$scale.color.green50 },
+      warning: { background: vars.$scale.color.carrot100 },
     },
   },
 });

--- a/client/src/shared/components/Modal/style.css.ts
+++ b/client/src/shared/components/Modal/style.css.ts
@@ -1,4 +1,3 @@
-import { colors } from '@karrotmarket/design-token';
 import { vars } from '@seed-design/design-token';
 import * as m from '@shared/styles/media.css';
 import * as u from '@shared/styles/utils.css';
@@ -46,7 +45,7 @@ export const modalOverlay = recipe({
     u.fullHeight,
     u.fullWidth,
     {
-      background: colors.light.scheme.$gray900,
+      background: vars.$scale.color.gray900,
       opacity: 0.3,
       zIndex: MODAL_Z_INDEX,
     },
@@ -97,7 +96,7 @@ export const modalCloseButton = style([
     margin: rem(5),
     transition: 'background 0.3s ease',
     ':hover': {
-      backgroundColor: colors.light.scheme.$gray100,
+      backgroundColor: vars.$scale.color.gray100,
     },
   },
 ]);
@@ -116,7 +115,7 @@ const modalBaseButton = style([
   {
     height: rem(45),
     fontSize: rem(14),
-    backgroundColor: colors.light.scheme.$blue800,
+    backgroundColor: vars.$scale.color.blue700,
     color: vars.$static.color.staticWhite,
     fontWeight: 'bold',
     transition: 'background 0.2s ease',

--- a/client/src/shared/styles/utils.css.ts
+++ b/client/src/shared/styles/utils.css.ts
@@ -1,4 +1,4 @@
-import { colors } from '@karrotmarket/design-token';
+import { vars } from '@seed-design/design-token';
 import { style } from '@vanilla-extract/css';
 
 export const positionAbsolute = style({
@@ -60,11 +60,11 @@ export const cursorNotAllowed = style({
 });
 
 export const border = style({
-  border: `1px solid ${colors.light.scheme.$gray300}`,
+  border: `1px solid ${vars.$scale.color.gray100}`,
 });
 
 export const border2 = style({
-  border: `1px solid ${colors.light.scheme.$gray400}`,
+  border: `1px solid ${vars.$scale.color.gray200}`,
 });
 
 export const borderNone = style({

--- a/client/src/token/Token.tsx
+++ b/client/src/token/Token.tsx
@@ -1,4 +1,4 @@
-import { colors } from '@karrotmarket/design-token';
+import { vars } from '@seed-design/design-token';
 import { Alert, Icon } from '@shared/components';
 import useClipboard from '@shared/hooks/useClipboard';
 import { act, fireEvent, render, screen } from '@shared/utils/test-utils';
@@ -33,7 +33,7 @@ function TokenPage() {
         <span className={style.clipBoardText}>{textToCopied}</span>
         <span className={style.clipBoardIconBox}>
           {isCopied ? (
-            <Icon icon="check" color={colors.light.scheme.$blue800} />
+            <Icon icon="check" color={vars.$scale.color.blue700} />
           ) : (
             <Icon icon="clip" />
           )}

--- a/client/src/token/style.css.ts
+++ b/client/src/token/style.css.ts
@@ -1,4 +1,4 @@
-import { colors } from '@karrotmarket/design-token';
+import { vars } from '@seed-design/design-token';
 import * as m from '@shared/styles/media.css';
 import * as t from '@shared/styles/token.css';
 import * as u from '@shared/styles/utils.css';
@@ -29,7 +29,7 @@ export const title = style([t.typography.heading4]);
 export const description = style([
   t.typography.caption1,
   {
-    color: colors.light.scheme.$gray700,
+    color: vars.$scale.color.gray700,
   },
 ]);
 
@@ -48,18 +48,18 @@ export const clipBoardContainer = recipe({
       border: 'none',
       padding: rem(10),
       height: rem(52),
-      backgroundColor: colors.light.scheme.$gray100,
+      backgroundColor: vars.$scale.color.gray100,
       justifyContent: 'space-between',
       transition: 'background 0.2s ease, border 0.2s ease',
 
       ':hover': {
-        backgroundColor: colors.light.scheme.$gray400,
+        backgroundColor: vars.$scale.color.gray300,
       },
     },
   ],
   variants: {
     isCopied: {
-      true: { border: `${rem(2)} solid ${colors.light.scheme.$blue800}` },
+      true: { border: `${rem(2)} solid ${vars.$scale.color.blue600}` },
       false: { border: `${rem(2)} solid white` },
     },
   },
@@ -73,13 +73,13 @@ export const linkButton = style([
   {
     height: rem(52),
     fontSize: rem(16),
-    backgroundColor: colors.light.scheme.$blue800,
+    backgroundColor: vars.$scale.color.blue500,
     color: 'white',
     fontWeight: 'bold',
     transition: 'background 0.2s ease',
 
     ':hover': {
-      backgroundColor: '#0A86B799',
+      backgroundColor: vars.$scale.color.blue600,
     },
   },
 ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1932,7 +1932,6 @@ __metadata:
     "@codepocket/schema": ^0.0.4
     "@codesandbox/sandpack-react": ^1.2.4
     "@codesandbox/sandpack-themes": ^1.0.0
-    "@karrotmarket/design-token": ^1.1.2
     "@mdx-js/react": ^1.6.22
     "@seed-design/design-token": ^1.0.0-alpha.0
     "@seed-design/stylesheet": ^1.0.0-beta.1
@@ -2922,13 +2921,6 @@ __metadata:
     "@jridgewell/resolve-uri": ^3.0.3
     "@jridgewell/sourcemap-codec": ^1.4.10
   checksum: b9537b9630ffb631aef9651a085fe361881cde1772cd482c257fe3c78c8fd5388d681f504a9c9fe1081b1c05e8f75edf55ee10fdb58d92bbaa8dbf6a7bd6b18c
-  languageName: node
-  linkType: hard
-
-"@karrotmarket/design-token@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "@karrotmarket/design-token@npm:1.1.2"
-  checksum: 9ec1524e9a573a07931d40cd4806692f5670721a6ec5247bd0449e0389088822a9a91496bfe422929a35aa12a2d663b1f2537fdba8e1dcebbf6ba6ff139e640c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
closes #183 

- `@seed-design/token` 으로 마이그레이션 했어요
- 전체적인 색을 조금 더 밝은 색으로 바꿨어요.
- 버튼들을 `outlined`가 아니라 `contain`으로 variant를 바꿨어요
- 전체적인 색 통일성을 맞췄어요 (파랑색 계열의 색을 쓰고 싶다면 `vars.$scale.color.blue500`을 쓰면 돼요, 600부터는 칙칙한 느낌이 나더라구요)

<img width="720" alt="스크린샷 2022-08-24 오후 4 23 08" src="https://user-images.githubusercontent.com/54893898/186356546-b1b2572a-3ebe-4995-a672-701003c7cea2.png">
 