### PR TITLE
client에서 코드 업데이트 시 이전 코드 가져오는 에러 해결

### DIFF
--- a/client/src/pocket/components/Modal/EditModal.tsx
+++ b/client/src/pocket/components/Modal/EditModal.tsx
@@ -7,7 +7,7 @@ import ModalContentTemplate, { OnConfirmModal } from './Template';
 
 const CreateModal = ({ closeModal, targetId }: ModalInterface) => {
   const { data: codeInfo } = useCode({ codeId: targetId });
-  const { updateCode } = useUpdateCode();
+  const { updateCode } = useUpdateCode({ codeId: targetId });
 
   const onConfirm = ({ code, codeName, isAnonymous }: OnConfirmModal) => {
     if (!closeModal) return;

--- a/client/src/pocket/hooks/useUpdateCode.ts
+++ b/client/src/pocket/hooks/useUpdateCode.ts
@@ -3,6 +3,7 @@ import {
   UpdateCodeResponse,
   updateCodeResponseValidate,
 } from '@codepocket/schema';
+import { getCodeByIdAPI } from '@shared/api';
 import useCustomMutation from '@shared/hooks/useCustomMutation';
 import { useQueryClient } from '@tanstack/react-query';
 
@@ -10,7 +11,12 @@ import { getCodesUrl } from '../api';
 
 type UpdateCodeBodyType = UpdateCodeRequest['body'];
 
-const useUpdateCode = () => {
+interface UseUpdateCode {
+  codeId?: string;
+  onError?: () => void;
+}
+
+const useUpdateCode = ({ codeId }: UseUpdateCode) => {
   const queryClient = useQueryClient();
   const { mutate: updateCodeMutate } = useCustomMutation<
     UpdateCodeResponse,
@@ -23,6 +29,7 @@ const useUpdateCode = () => {
     options: {
       onSuccess: async () => {
         await queryClient.invalidateQueries([getCodesUrl]);
+        await queryClient.invalidateQueries([getCodeByIdAPI, { codeId }]);
       },
     },
   });

--- a/client/src/shared/api.ts
+++ b/client/src/shared/api.ts
@@ -1,0 +1,1 @@
+export const getCodeByIdAPI = '/code/id';

--- a/client/src/shared/hooks/useCode.ts
+++ b/client/src/shared/hooks/useCode.ts
@@ -1,4 +1,5 @@
 import { GetCodeResponse, getCodeResponseValidate } from '@codepocket/schema';
+import { getCodeByIdAPI } from '@shared/api';
 import useCustomQuery from '@shared/hooks/useCustomQuery';
 
 interface UseCode {
@@ -8,7 +9,7 @@ interface UseCode {
 
 const useCode = ({ codeId, onError }: UseCode) =>
   useCustomQuery<GetCodeResponse>({
-    url: '/code/id',
+    url: getCodeByIdAPI,
     validator: getCodeResponseValidate,
     params: { codeId: `${codeId}` },
     options: { onError },


### PR DESCRIPTION
closes #199 
closes #172 

- 기존에 코드를 업데이트 후 다시 수정하기 모달을 열면 최신으로 변경이 되지 않는 오류가 있어 해결해주었어요
- 172번 오류가 어느샌가 해결되었더라구요
