### PR TITLE
detail페이지에서 dependency를 구할 때 확장자 체크

### DIFF
--- a/client/src/detail/Detail.tsx
+++ b/client/src/detail/Detail.tsx
@@ -15,7 +15,7 @@ import useStory from './hooks/useStory';
 import useStoryNames from './hooks/useStoryNames';
 import * as style from './style.css';
 import { createObjWithCertainValue } from './utils/filterObj';
-import { getDependenciesFromText } from './utils/parse';
+import { checkWordInArray, getDependenciesFromText } from './utils/parse';
 import { genrateBaseCode } from './utils/textGenerator';
 
 // TODO: Suspense 적용하기
@@ -39,10 +39,10 @@ const DetailPage: React.FC = () => {
 
   const ROOT_FILE = '/App.tsx';
   const VERSION = 'latest';
-  const dependencies = createObjWithCertainValue(
-    getDependenciesFromText(codeDataRes?.code || ''),
-    VERSION,
-  );
+  const dependencies =
+    codeDataRes && checkWordInArray(codeDataRes.codeName, ['js', 'jsx', 'ts', 'tsx'])
+      ? createObjWithCertainValue(getDependenciesFromText(codeDataRes.code || ''), VERSION)
+      : createObjWithCertainValue(getDependenciesFromText(codeDataRes?.code || ''), VERSION);
   const files = {
     [ROOT_FILE]: genrateBaseCode(codeDataRes?.codeName || ''),
     [`/${codeDataRes?.codeName}`]: codeDataRes?.code || '',

--- a/client/src/detail/Detail.tsx
+++ b/client/src/detail/Detail.tsx
@@ -42,7 +42,7 @@ const DetailPage: React.FC = () => {
   const dependencies =
     codeDataRes && checkWordInArray(codeDataRes.codeName, ['js', 'jsx', 'ts', 'tsx'])
       ? createObjWithCertainValue(getDependenciesFromText(codeDataRes.code || ''), VERSION)
-      : createObjWithCertainValue(getDependenciesFromText(codeDataRes?.code || ''), VERSION);
+      : {};
   const files = {
     [ROOT_FILE]: genrateBaseCode(codeDataRes?.codeName || ''),
     [`/${codeDataRes?.codeName}`]: codeDataRes?.code || '',

--- a/client/src/detail/utils/parse.ts
+++ b/client/src/detail/utils/parse.ts
@@ -9,3 +9,5 @@ export const getExtension = (filename: string) => filename.split('.').pop() || '
 
 export const convertFirstToUpperCase = <T extends string>(str: string) =>
   (str.slice(0, 1).toUpperCase() + str.slice(1)) as T;
+
+export const checkWordInArray = (word: string, words: string[]) => words.includes(word);


### PR DESCRIPTION
closes #202 

- 예상한대로 import파싱시에 문제가 발생했어요.
- 우선 임시방편으로 해놓았는데 근본적인 문제 해결이 필요해요

### 문제상황
- 파이썬 파일 경우 import문이 조금 다른데 이거를 정규식을 돌렸을 때 에러가 나는 것도 아니고 뭔가 멈추는 현상이 발생해요
  - [관련 사례](https://stackoverflow.com/questions/53333558/regex-error-the-expression-took-longer-than-250ms-to-execute)
- 우선 js, jsx, ts, tsx파일의 경우에만 정규식을 돌도록 해주었어요
- 하지만 이 파일들에서 import불러오는 양식이 다르다면 같은 에러가 발생할 여지가 있어요
- 아래 사항들에 대해 추가적인 논의가 필요해요

### 추가논의
- js, jsx, ts, tsx이외 파일들에 대한 대응 => 우선은 지원하지 않는걸로?
- js, jsx, ts, tsx에서도 잘못된 import 문이 들어왔을 때 대한 대응 => 기존 정규식 수정해야할 듯?
