### PR TITLE
chore: setup-node action을 사용하여 의존성 캐싱 적용

### DIFF
--- a/.github/workflows/deploy-codepocket-external.yml
+++ b/.github/workflows/deploy-codepocket-external.yml
@@ -19,10 +19,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16.16.0'
+          cache: yarn
 
       - name: 의존성을 설치해요
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: yarn install
+        run: yarn install --immutable 
 
       - name: schema 프로젝트를 빌드해요
         working-directory: ./schema

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,8 +9,15 @@ jobs:
   Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: yarn
-        run: yarn
+      - uses: actions/checkout@v3
+      
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.16.0'
+          cache: yarn
+
+      - name: install dependencies
+        run: yarn install --immutable
+
       - name: check lint
         run: yarn lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,15 @@ jobs:
   Test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: yarn
-        run: yarn
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.16.0'
+          cache: yarn
+
+      - name: install dependencies
+        run: yarn install --immutable
 
       - name: set env var
         run: |


### PR DESCRIPTION
## Description

`actions/setup-node@v3`를 사용하여 의존성을 캐싱하도록 워크플로우를 변경했습니다.

### AS-IS

```yml
- uses: actions/checkout@v3

- uses: actions/setup-node@v3
  with:
    node-version: '16.16.0'

- name: 의존성을 설치해요
  if: steps.yarn-cache.outputs.cache-hit != 'true'
  run: yarn install
```

### TO-BE

```yml
- uses: actions/checkout@v3

- uses: actions/setup-node@v3
  with:
    node-version: '16.16.0'
    cache: yarn

- name: 의존성을 설치해요
  run: yarn install --immutable
```

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
- [https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)