### PR TITLE
fix: 필요하지 않은 development 체크 제거

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -13,7 +13,6 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 
 const queryClient = new QueryClient();
-const isDev = process.env.NODE_ENV === 'development';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
@@ -22,7 +21,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
         <QueryClientProvider client={queryClient}>
           <ModalProvider>
             <App />
-            {isDev && <ReactQueryDevtools initialIsOpen={false} />}
+            <ReactQueryDevtools initialIsOpen={false} />
           </ModalProvider>
         </QueryClientProvider>
       </Auth0Provider>


### PR DESCRIPTION
좋은 서비스 제공해주셔서 감사합니다.
내부 코드를 살펴보던중 `ReactQueryDevtools` 를 `environment` 가 `development` `production` 모드에 따라서 수동적으로 랜더링이 제어되고 있는것을 발견했습니다.
제가 알고 있는 바에 따르면, ReactQueryDevtools 내부에서 자동적으로 `environment` 에 따른 랜더링을 제어해주는것으로 알고 있습니다.

불필요한 제어 코드를 삭제하였습니다.

## [react-query-devtools](https://github.com/TanStack/query/blob/main/packages/react-query-devtools/src/index.ts)
<img width="620" alt="image" src="https://user-images.githubusercontent.com/69495129/200721260-de8d4e65-aaa4-43e0-b508-ddf8dea5a521.png">

## [공식문서 참고자료 Devtools in production](https://tanstack.com/query/v4/docs/devtools#devtools-in-production)


감사합니다.